### PR TITLE
Update README to fix Python script

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ one_gadget('b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0')
 ```python
 import subprocess
 def one_gadget(filename):
-  return map(int, subprocess.check_output(['one_gadget', '--raw', filename]).split(' '))
+  return [int(i) for i in subprocess.check_output(['one_gadget', '--raw', filename]).decode().split(' ')]
 
 one_gadget('/lib/x86_64-linux-gnu/libc.so.6')
 #=> [324293, 324386, 1090444]

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -137,7 +137,7 @@ RUBY_OUTPUT_OF(one_gadget('b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0'))
 ```python
 import subprocess
 def one_gadget(filename):
-  return map(int, subprocess.check_output(['one_gadget', '--raw', filename]).split(' '))
+  return [int(i) for i in subprocess.check_output(['one_gadget', '--raw', filename]).decode().split(' ')]
 
 RUBY_OUTPUT_OF(one_gadget('/lib/x86_64-linux-gnu/libc.so.6'))
 ```


### PR DESCRIPTION
Updated the Python script in the README file.

`check_output()` returns `bytes`, not `string` so the `.decode()` method is required.

Also, `map` returns an iterator which could be hard to work with so the function was updated to return a list.