### PR TITLE
Check for false positives in jmp_case_candidates

### DIFF
--- a/lib/one_gadget/fetchers/amd64.rb
+++ b/lib/one_gadget/fetchers/amd64.rb
@@ -44,7 +44,9 @@ module OneGadget
           jmp_addr = cand.last.scan(/jmp\s+([\da-f]+)\s/)[0][0].to_i(16)
           dump = `#{@objdump.command(start: jmp_addr, stop: jmp_addr + 100)}|egrep '[0-9a-f]+:'`
           remain = dump.lines.map(&:strip).reject(&:empty?)
-          remain = remain[0..remain.index { |r| r.match(/call.*<execve[^+]*>/) }]
+          call_execve = remain.index { |r| r.match(/call.*<execve[^+]*>/) }
+          next if call_execve.nil?
+          remain = remain[0..call_execve]
           [cand + remain].join("\n")
         end.compact
       end

--- a/lib/one_gadget/fetchers/amd64.rb
+++ b/lib/one_gadget/fetchers/amd64.rb
@@ -46,6 +46,7 @@ module OneGadget
           remain = dump.lines.map(&:strip).reject(&:empty?)
           call_execve = remain.index { |r| r.match(/call.*<execve[^+]*>/) }
           next if call_execve.nil?
+
           remain = remain[0..call_execve]
           [cand + remain].join("\n")
         end.compact


### PR DESCRIPTION
Add a check for gadgets that don't end in a `call execve` in `jmp_case_candidates()`
This avoids an error in Ruby versions < 2.6.0 when passing `nil` to a range.

Resolves #197 