### PR TITLE
Replace obsolecent egrep with grep -E

### DIFF
--- a/lib/one_gadget/fetchers/amd64.rb
+++ b/lib/one_gadget/fetchers/amd64.rb
@@ -33,7 +33,7 @@ module OneGadget
       #   ...
       #   call execve
       def jmp_case_candidates
-        `#{@objdump.command}|egrep '# #{bin_sh_hex}' -A 8`.split('--').map do |cand|
+        `#{@objdump.command}|grep -E '# #{bin_sh_hex}' -A 8`.split('--').map do |cand|
           cand = cand.lines.map(&:strip).reject(&:empty?)
           jmp_at = cand.index { |c| c.include?('jmp') }
           next nil if jmp_at.nil?
@@ -42,7 +42,7 @@ module OneGadget
           next if cand.any? { |c| c.include?(call_str) }
 
           jmp_addr = cand.last.scan(/jmp\s+([\da-f]+)\s/)[0][0].to_i(16)
-          dump = `#{@objdump.command(start: jmp_addr, stop: jmp_addr + 100)}|egrep '[0-9a-f]+:'`
+          dump = `#{@objdump.command(start: jmp_addr, stop: jmp_addr + 100)}|grep -E '[0-9a-f]+:'`
           remain = dump.lines.map(&:strip).reject(&:empty?)
           call_execve = remain.index { |r| r.match(/call.*<execve[^+]*>/) }
           next if call_execve.nil?

--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -51,7 +51,7 @@ module OneGadget
       def candidates(&block)
         call_regexp = "#{call_str}.*<(exec[^+]*|posix_spawn[^+]*)>$"
         cands = []
-        `#{@objdump.command}|egrep '#{call_regexp}' -B 30`.split('--').each do |cand|
+        `#{@objdump.command}|grep -E '#{call_regexp}' -B 30`.split('--').each do |cand|
           lines = cand.lines.map(&:strip).reject(&:empty?)
           # split with call_regexp
           loop do


### PR DESCRIPTION
Fixes the warnings occurring with recent grep versions.

Currently, the output with grep version 3.8 looks like this:
```
$ one_gadget libc-2.31.so
egrep: warning: egrep is obsolescent; using grep -E
egrep: warning: egrep is obsolescent; using grep -E
egrep: warning: egrep is obsolescent; using grep -E
egrep: warning: egrep is obsolescent; using grep -E
egrep: warning: egrep is obsolescent; using grep -E
0xe3afe execve("/bin/sh", r15, r12)
constraints:
  [r15] == NULL || r15 == NULL
  [r12] == NULL || r12 == NULL

0xe3b01 execve("/bin/sh", r15, rdx)
constraints:
  [r15] == NULL || r15 == NULL
  [rdx] == NULL || rdx == NULL

0xe3b04 execve("/bin/sh", rsi, rdx)
constraints:
  [rsi] == NULL || rsi == NULL
  [rdx] == NULL || rdx == NULL
```

this PR removes those warnings :)