### PR TITLE
Support JSON output

### DIFF
--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -56,6 +56,8 @@ module OneGadget
         }
       end
 
+      # To have this class can be serialized in JSON.
+      # @return [String]
       def to_json(*)
         to_obj.to_json
       end

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 require 'one_gadget/abi'
 require 'one_gadget/emulators/lambda'
 require 'one_gadget/error'
@@ -52,6 +54,10 @@ module OneGadget
           effect:,
           constraints:
         }
+      end
+
+      def to_json(*)
+        to_obj.to_json
       end
 
       # @return [Integer]

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -28,13 +28,12 @@ module OneGadget
         @base = 0
         @offset = offset
         @constraints = options[:constraints] || []
-        @effect = options[:effect]
+        @effect = options[:effect] || ''
       end
 
       # Show gadget in a pretty way.
       def inspect
-        str = OneGadget::Helper.hex(value)
-        str += effect ? " #{effect}\n" : "\n"
+        str = "#{OneGadget::Helper.hex(value)} #{effect}\n"
         unless constraints.empty?
           str += "#{OneGadget::Helper.colorize('constraints')}:\n  "
           str += merge_constraints.join("\n  ")
@@ -44,6 +43,15 @@ module OneGadget
           str.gsub!(/([^\w])(#{reg})([^\w])/, "\\1#{OneGadget::Helper.colorize('\2', sev: :reg)}\\3")
         end
         "#{str}\n"
+      end
+
+      # @return [Hash]
+      def to_obj
+        {
+          value:,
+          effect:,
+          constraints:
+        }
       end
 
       # @return [Integer]

--- a/spec/bin_spec.rb
+++ b/spec/bin_spec.rb
@@ -16,7 +16,9 @@ Usage: one_gadget <FILE|-b BuildID> [options]
                                      Increase this level to ask OneGadget show more gadgets it found.
                                      Default: 0
     -n, --near FUNCTIONS/FILE        Order gadgets by their distance to the given functions or to the GOT functions of the given file.
-    -r, --[no-]raw                   Output gadgets offset only, split with one space.
+    -o, --output-format FORMAT       Output format. FORMAT should be one of <pretty|raw|json>.
+                                     Default: pretty
+    -r, --raw                        Alias of -o raw. Output gadgets offset only, split with one space.
     -s, --script exploit-script      Run exploit script with all possible gadgets.
                                      The script will be run as 'exploit-script $offset'.
         --info BuildID               Show version information given BuildID.

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -201,4 +201,20 @@ constraints:
       EOS
     end
   end
+
+  context 'json' do
+    it 'normal case' do
+      argv = b_param + %w[--output-format json]
+      expect { hook_logger { described_class.work(argv) } }.to output(<<-EOS).to_stdout
+[{"value":324286,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, \\"-c\\", r12, NULL} is a valid argv"]},{"value":324293,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, rax, r12, NULL} is a valid argv"]},{"value":324386,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv"]},{"value":1090444,"effect":"execve(\\"/bin/sh\\", rsp+0x70, environ)","constraints":["[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv"]}]
+      EOS
+    end
+
+    it 'with near' do
+      argv = [libc_file] + %w[-o json --near exit,mkdir]
+      expect { hook_logger { described_class.work(argv) } }.to output(<<-EOS).to_stdout
+[{"near":"exit","near_offset":274720,"gadgets":[{"value":324286,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, \\"-c\\", r12, NULL} is a valid argv"]},{"value":324293,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, rax, r12, NULL} is a valid argv"]},{"value":324386,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv"]},{"value":1090444,"effect":"execve(\\"/bin/sh\\", rsp+0x70, environ)","constraints":["[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv"]}]},{"near":"mkdir","near_offset":1113008,"gadgets":[{"value":1090444,"effect":"execve(\\"/bin/sh\\", rsp+0x70, environ)","constraints":["[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv"]},{"value":324386,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv"]},{"value":324293,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, rax, r12, NULL} is a valid argv"]},{"value":324286,"effect":"execve(\\"/bin/sh\\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, \\"-c\\", r12, NULL} is a valid argv"]}]}]
+      EOS
+    end
+  end
 end

--- a/spec/gadget_spec.rb
+++ b/spec/gadget_spec.rb
@@ -48,6 +48,12 @@ constraints:
                                     constraints: ['[rsp+0x30] == NULL', 'rax == 0']
                                   })
     end
+
+    it 'to_json' do
+      gadget = OneGadget::Gadget::Gadget.new(0x1234, constraints: ['everything is fine'],
+                                                     effect: 'side')
+      expect(gadget.to_json).to eq('{"value":4660,"effect":"side","constraints":["everything is fine"]}')
+    end
   end
 
   context 'score' do

--- a/spec/gadget_spec.rb
+++ b/spec/gadget_spec.rb
@@ -38,6 +38,18 @@ constraints:
     end
   end
 
+  context 'to_obj' do
+    it 'simple' do
+      gadget = OneGadget::Gadget::Gadget.new(0x1234, constraints: ['[rsp+0x30] == NULL', 'rax == 0'],
+                                                     effect: 'execve("/bin/sh", rsp+0x30, rax)')
+      expect(gadget.to_obj).to eq({
+                                    value: 0x1234,
+                                    effect: 'execve("/bin/sh", rsp+0x30, rax)',
+                                    constraints: ['[rsp+0x30] == NULL', 'rax == 0']
+                                  })
+    end
+  end
+
   context 'score' do
     def new(cons)
       OneGadget::Gadget::Gadget.new(0, constraints: cons)


### PR DESCRIPTION
Introduce a new CLI argument `--output-format FORMAT` (or `-o FORMAT`) with `FORMAT` can be one of `pretty`, `raw`, and `json`.

* `--raw` is still available but it becomes an alias to `-o raw`.
* `--[no-]raw` is removed.

Examples of JSON output:

```sh
$ one_gadget -b b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0 -o json -l1
[{"value":324279,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","{\"sh\", \"-c\", r12, NULL} is a valid argv"]},{"value":324286,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, \"-c\", r12, NULL} is a valid argv"]},{"value":324293,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, rax, r12, NULL} is a valid argv"]},{"value":324386,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv"]},{"value":939679,"effect":"execve(\"/bin/sh\", r14, r12)","constraints":["[r14] == NULL || r14 == NULL || r14 is a valid argv","[r12] == NULL || r12 == NULL || r12 is a valid envp"]},{"value":940120,"effect":"execve(\"/bin/sh\", [rbp-0x88], [rbp-0x70])","constraints":["[[rbp-0x88]] == NULL || [rbp-0x88] == NULL || [rbp-0x88] is a valid argv","[[rbp-0x70]] == NULL || [rbp-0x70] == NULL || [rbp-0x70] is a valid envp"]},{"value":940127,"effect":"execve(\"/bin/sh\", r10, [rbp-0x70])","constraints":["[r10] == NULL || r10 == NULL || r10 is a valid argv","[[rbp-0x70]] == NULL || [rbp-0x70] == NULL || [rbp-0x70] is a valid envp"]},{"value":940131,"effect":"execve(\"/bin/sh\", r10, rdx)","constraints":["[r10] == NULL || r10 == NULL || r10 is a valid argv","[rdx] == NULL || rdx == NULL || rdx is a valid envp"]},{"value":1090444,"effect":"execve(\"/bin/sh\", rsp+0x70, environ)","constraints":["[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv"]},{"value":1090456,"effect":"execve(\"/bin/sh\", rsi, [rax])","constraints":["[rsi] == NULL || rsi == NULL || rsi is a valid argv","[[rax]] == NULL || [rax] == NULL || [rax] is a valid envp"]}]
```

```
$ one_gadget spec/data/libc-2.27-b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0.so -o json --near exit,mkdir
[{"near":"exit","near_offset":274720,"gadgets":[{"value":324286,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, \"-c\", r12, NULL} is a valid argv"]},{"value":324293,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, rax, r12, NULL} is a valid argv"]},{"value":324386,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv"]},{"value":1090444,"effect":"execve(\"/bin/sh\", rsp+0x70, environ)","constraints":["[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv"]}]},{"near":"mkdir","near_offset":1113008,"gadgets":[{"value":1090444,"effect":"execve(\"/bin/sh\", rsp+0x70, environ)","constraints":["[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv"]},{"value":324386,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv"]},{"value":324293,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, rax, r12, NULL} is a valid argv"]},{"value":324286,"effect":"execve(\"/bin/sh\", rsp+0x40, environ)","constraints":["rsp & 0xf == 0","writable: rsp+0x50","rcx == NULL || {rcx, \"-c\", r12, NULL} is a valid argv"]}]}]
```

Also confirmed the output can be parsed by Python3:

```sh
$ one_gadget spec/data/libc-2.27-b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0.so -o json -l1 | python3  -c 'print(__import__("json").loads(__import__("sys").stdin.read()))'
[{'value': 324279, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['rsp & 0xf == 0', 'writable: rsp+0x50', '{"sh", "-c", r12, NULL} is a valid argv']}, {'value': 324286, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['rsp & 0xf == 0', 'writable: rsp+0x50', 'rcx == NULL || {rcx, "-c", r12, NULL} is a valid argv']}, {'value': 324293, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['rsp & 0xf == 0', 'writable: rsp+0x50', 'rcx == NULL || {rcx, rax, r12, NULL} is a valid argv']}, {'value': 324386, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv']}, {'value': 939679, 'effect': 'execve("/bin/sh", r14, r12)', 'constraints': ['[r14] == NULL || r14 == NULL || r14 is a valid argv', '[r12] == NULL || r12 == NULL || r12 is a valid envp']}, {'value': 940120, 'effect': 'execve("/bin/sh", [rbp-0x88], [rbp-0x70])', 'constraints': ['[[rbp-0x88]] == NULL || [rbp-0x88] == NULL || [rbp-0x88] is a valid argv', '[[rbp-0x70]] == NULL || [rbp-0x70] == NULL || [rbp-0x70] is a valid envp']}, {'value': 940127, 'effect': 'execve("/bin/sh", r10, [rbp-0x70])', 'constraints': ['[r10] == NULL || r10 == NULL || r10 is a valid argv', '[[rbp-0x70]] == NULL || [rbp-0x70] == NULL || [rbp-0x70] is a valid envp']}, {'value': 940131, 'effect': 'execve("/bin/sh", r10, rdx)', 'constraints': ['[r10] == NULL || r10 == NULL || r10 is a valid argv', '[rdx] == NULL || rdx == NULL || rdx is a valid envp']}, {'value': 1090444, 'effect': 'execve("/bin/sh", rsp+0x70, environ)', 'constraints': ['[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv']}, {'value': 1090456, 'effect': 'execve("/bin/sh", rsi, [rax])', 'constraints': ['[rsi] == NULL || rsi == NULL || rsi is a valid argv', '[[rax]] == NULL || [rax] == NULL || [rax] is a valid envp']}]
```

```sh
 one_gadget spec/data/libc-2.27-b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0.so -o json --near exit,mkdir | python3  -c 'print(__import__("json").loads(__import__("sys").stdin.read()))'
[{'near': 'exit', 'near_offset': 274720, 'gadgets': [{'value': 324286, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['rsp & 0xf == 0', 'writable: rsp+0x50', 'rcx == NULL || {rcx, "-c", r12, NULL} is a valid argv']}, {'value': 324293, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['rsp & 0xf == 0', 'writable: rsp+0x50', 'rcx == NULL || {rcx, rax, r12, NULL} is a valid argv']}, {'value': 324386, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv']}, {'value': 1090444, 'effect': 'execve("/bin/sh", rsp+0x70, environ)', 'constraints': ['[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv']}]}, {'near': 'mkdir', 'near_offset': 1113008, 'gadgets': [{'value': 1090444, 'effect': 'execve("/bin/sh", rsp+0x70, environ)', 'constraints': ['[rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv']}, {'value': 324386, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['[rsp+0x40] == NULL || {[rsp+0x40], [rsp+0x48], [rsp+0x50], [rsp+0x58], ...} is a valid argv']}, {'value': 324293, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['rsp & 0xf == 0', 'writable: rsp+0x50', 'rcx == NULL || {rcx, rax, r12, NULL} is a valid argv']}, {'value': 324286, 'effect': 'execve("/bin/sh", rsp+0x40, environ)', 'constraints': ['rsp & 0xf == 0', 'writable: rsp+0x50', 'rcx == NULL || {rcx, "-c", r12, NULL} is a valid argv']}]}]
```

Fixes #224 