### PR TITLE
Explicitly specify logger dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     one_gadget (1.10.0)
       elftools (>= 1.0.2, < 1.4.0)
+      logger
 
 GEM
   remote: https://rubygems.org/
@@ -15,6 +16,7 @@ GEM
       bindata (~> 2)
     json (2.9.0)
     language_server-protocol (3.17.0.3)
+    logger (1.6.5)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)

--- a/one_gadget.gemspec
+++ b/one_gadget.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1'
 
   s.add_dependency 'elftools', '>= 1.0.2', '< 1.4.0'
+  s.add_dependency 'logger'
 
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.7'


### PR DESCRIPTION
On Ruby 3.5 the logger gem is no longer shipped with Ruby. Explicitly add the gem dependency to prevent warnings on Ruby 3.4 and errors on Ruby 3.5.

Reference: https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c