### PR TITLE
Rename Fetcher namespace to plural Fetchers

### DIFF
--- a/docs/adding-an-architecture.md
+++ b/docs/adding-an-architecture.md
@@ -5,7 +5,7 @@ existing example to copy is **aarch64** (`lib/one_gadget/fetchers/aarch64.rb` an
 `lib/one_gadget/emulators/aarch64.rb`).
 
 ```ruby
-OneGadget::Fetcher::<Arch>  < OneGadget::Fetcher::Base       # find candidates, describe constraints
+OneGadget::Fetchers::<Arch>  < OneGadget::Fetchers::Base       # find candidates, describe constraints
 OneGadget::Emulators::<Arch> < OneGadget::Emulators::Processor # symbolically execute a candidate
 ```
 
@@ -28,8 +28,8 @@ flowchart LR
 
   subgraph FE["Fetcher side: find candidate sequences"]
     direction TB
-    FB["Fetcher::Base<br/>(engine)"]:::engine
-    FA["Fetcher::&lt;Arch&gt;<br/>(you implement)"]:::arch
+    FB["Fetchers::Base<br/>(engine)"]:::engine
+    FA["Fetchers::&lt;Arch&gt;<br/>(you implement)"]:::arch
     FB -->|inherits| FA
   end
   subgraph EM["Emulator side: execute one candidate"]
@@ -49,8 +49,8 @@ Legend: 🟦 engine (shared base) · 🟩 what you implement · 🟪 shared mixi
 
 What each box is for:
 
-- **`Fetcher::Base`** — the engine: walks the CFG for candidate sequences, then solves and trims gadgets.
-- **`Fetcher::<Arch>`** — the arch's disassembly, its string/branch recognition, and how to build its emulator.
+- **`Fetchers::Base`** — the engine: walks the CFG for candidate sequences, then solves and trims gadgets.
+- **`Fetchers::<Arch>`** — the arch's disassembly, its string/branch recognition, and how to build its emulator.
 - **`Emulators::Processor`** — the engine: parse an instruction, track register/stack state, collect constraints.
 - **`module Conditional`** — shared compare/branch machinery; a crossed branch becomes a gadget constraint.
 - **`module ArmFamily`** — logic shared by arm and aarch64 (calling convention, memory model, condition codes).
@@ -67,7 +67,7 @@ flowchart TD
   classDef mixin fill:#ede9fe,stroke:#7c3aed,color:#4c1d95,font-family:monospace
   classDef out fill:#ffe4e6,stroke:#e11d48,color:#881337,font-family:monospace
 
-  A["OneGadget.gadgets(file)"]:::entry --> B["Fetcher::&lt;Arch&gt;#find"]:::arch
+  A["OneGadget.gadgets(file)"]:::entry --> B["Fetchers::&lt;Arch&gt;#find"]:::arch
   B --> C["Base#candidates<br/>(backward CFG walk)"]:::engine
   C --> D{"for each start instruction"}
   D --> E["Base#emulate<br/>(process! per instruction)"]:::engine
@@ -88,7 +88,7 @@ Reading the flow:
 - **`resolve`** reads the call's arguments (`argument`, `str_bin_sh?`, `global_var?`) and builds the argv/envp constraints.
 - finally, a contradiction drops the gadget and a tautology is stripped.
 
-## The fetcher — `Fetcher::<Arch> < Fetcher::Base`
+## The fetcher — `Fetchers::<Arch> < Fetchers::Base`
 
 | Method | What it returns |
 | --- | --- |
@@ -113,7 +113,7 @@ Optional hooks (sensible defaults in `Base`):
 | Method | Default | Purpose |
 | --- | --- | --- |
 | `objdump_options` | `[]` | extra objdump flags, e.g. x86 returns `%w[-M intel]` |
-| `terminal_call_sites` | `nil` | if the calls can be located cheaply *without* disassembling everything, return their addresses for windowed disassembly (a big win when a full objdump is slow, as on Thumb-2 arm). `nil` = disassemble the whole file. See `Fetcher::Arm`. |
+| `terminal_call_sites` | `nil` | if the calls can be located cheaply *without* disassembling everything, return their addresses for windowed disassembly (a big win when a full objdump is slow, as on Thumb-2 arm). `nil` = disassemble the whole file. See `Fetchers::Arm`. |
 
 ## The emulator — `Emulators::<Arch> < Emulators::Processor`
 
@@ -162,7 +162,7 @@ a shared base — arm/aarch64 share theirs through `ArmFamily`):
 ## Wiring
 
 * `OneGadget::Helper.architecture` — map the ELF machine string to your arch symbol.
-* `OneGadget::Fetcher.from_file` — add the arch symbol → `Fetcher::<Arch>` entry.
+* `OneGadget::Fetchers.from_file` — add the arch symbol → `Fetchers::<Arch>` entry.
 * `OneGadget::Helper.arch_specific_objdump` — the cross objdump binary name.
 
 ## Tests

--- a/lib/one_gadget/emulators/conditional.rb
+++ b/lib/one_gadget/emulators/conditional.rb
@@ -7,7 +7,7 @@ module OneGadget
     # Shared modelling of compare instructions and conditional branches.
     #
     # A gadget candidate may cross a conditional branch: the fetcher stitches the
-    # actual taken/not-taken path (see {OneGadget::Fetcher::Base#candidates}), and
+    # actual taken/not-taken path (see {OneGadget::Fetchers::Base#candidates}), and
     # the emulator turns the branch decision into a gadget constraint.
     #
     # Branches are resolved with one line of look-ahead: at the branch we record a

--- a/lib/one_gadget/fetchers.rb
+++ b/lib/one_gadget/fetchers.rb
@@ -10,7 +10,7 @@ require 'one_gadget/helper'
 
 module OneGadget
   # To find gadgets.
-  module Fetcher
+  module Fetchers
     # Define class methods here.
     module ClassMethods
       # Fetch one-gadget offsets of this build id.
@@ -31,10 +31,10 @@ module OneGadget
       def from_file(file)
         arch = OneGadget::Helper.architecture(file)
         klass = {
-          aarch64: OneGadget::Fetcher::AArch64,
-          amd64: OneGadget::Fetcher::Amd64,
-          arm: OneGadget::Fetcher::Arm,
-          i386: OneGadget::Fetcher::I386
+          aarch64: OneGadget::Fetchers::AArch64,
+          amd64: OneGadget::Fetchers::Amd64,
+          arm: OneGadget::Fetchers::Arm,
+          i386: OneGadget::Fetchers::I386
         }[arch]
         raise Error::UnsupportedArchitectureError, arch if klass.nil?
 

--- a/lib/one_gadget/fetchers/aarch64.rb
+++ b/lib/one_gadget/fetchers/aarch64.rb
@@ -4,7 +4,7 @@ require 'one_gadget/emulators/aarch64'
 require 'one_gadget/fetchers/base'
 
 module OneGadget
-  module Fetcher
+  module Fetchers
     # Define common methods for gadget fetchers.
     class AArch64 < Base
       # aarch64 condition codes (used to recognise +b.<cond>+ branches).

--- a/lib/one_gadget/fetchers/amd64.rb
+++ b/lib/one_gadget/fetchers/amd64.rb
@@ -4,9 +4,9 @@ require 'one_gadget/emulators/amd64'
 require 'one_gadget/fetchers/x86'
 
 module OneGadget
-  module Fetcher
+  module Fetchers
     # Fetcher for amd64.
-    class Amd64 < OneGadget::Fetcher::X86
+    class Amd64 < OneGadget::Fetchers::X86
       private
 
       def emulator

--- a/lib/one_gadget/fetchers/arm.rb
+++ b/lib/one_gadget/fetchers/arm.rb
@@ -6,7 +6,7 @@ require 'one_gadget/emulators/arm'
 require 'one_gadget/fetchers/base'
 
 module OneGadget
-  module Fetcher
+  module Fetchers
     # Fetcher for 32-bit ARM (A32 / Thumb-2).
     class Arm < Base
       # Condition codes as branch suffixes (+bne+, +bcs+, ...).

--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -4,7 +4,7 @@ require 'one_gadget/error'
 require 'one_gadget/fetchers/objdump'
 
 module OneGadget
-  module Fetcher
+  module Fetchers
     # Base of the per-architecture gadget fetchers. It discovers candidate
     # instruction sequences - a backward control-flow walk from each
     # +exec+/+posix_spawn+ call - and turns a solved candidate into a

--- a/lib/one_gadget/fetchers/i386.rb
+++ b/lib/one_gadget/fetchers/i386.rb
@@ -6,9 +6,9 @@ require 'one_gadget/emulators/i386'
 require 'one_gadget/fetchers/x86'
 
 module OneGadget
-  module Fetcher
+  module Fetchers
     # Fetcher for i386.
-    class I386 < OneGadget::Fetcher::X86
+    class I386 < OneGadget::Fetchers::X86
       private
 
       def candidates

--- a/lib/one_gadget/fetchers/objdump.rb
+++ b/lib/one_gadget/fetchers/objdump.rb
@@ -6,7 +6,7 @@ require 'one_gadget/error'
 require 'one_gadget/helper'
 
 module OneGadget
-  module Fetcher
+  module Fetchers
     # Utilities for fetching instructions from libc using objdump.
     class Objdump
       # Instantiate an {Objdump} object.

--- a/lib/one_gadget/fetchers/x86.rb
+++ b/lib/one_gadget/fetchers/x86.rb
@@ -4,7 +4,7 @@ require 'one_gadget/emulators/x86'
 require 'one_gadget/fetchers/base'
 
 module OneGadget
-  module Fetcher
+  module Fetchers
     # Define common methods for gadget fetchers.
     class X86 < Base
       # Conditional-jump mnemonics (shared with the emulator).

--- a/lib/one_gadget/one_gadget.rb
+++ b/lib/one_gadget/one_gadget.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'one_gadget/error'
-require 'one_gadget/fetcher'
+require 'one_gadget/fetchers'
 require 'one_gadget/helper'
 require 'one_gadget/logger'
 
@@ -31,7 +31,7 @@ module OneGadget
     #   OneGadget.gadgets(build_id: '60131540dadc6796cab33388349e6e4e68692053')
     def gadgets(file: nil, build_id: nil, details: false, force_file: false, level: 0)
       ret = if build_id
-              OneGadget::Fetcher.from_build_id(build_id) || OneGadget::Logger.not_found(build_id)
+              OneGadget::Fetchers.from_build_id(build_id) || OneGadget::Logger.not_found(build_id)
             else
               from_file(OneGadget::Helper.abspath(file), force: force_file)
             end
@@ -49,14 +49,14 @@ module OneGadget
     def from_file(path, force: false)
       OneGadget::Helper.verify_elf_file!(path)
       gadgets = try_from_build(path) unless force
-      gadgets || OneGadget::Fetcher.from_file(path)
+      gadgets || OneGadget::Fetchers.from_file(path)
     end
 
     def try_from_build(file)
       build_id = OneGadget::Helper.build_id_of(file)
       return unless build_id
 
-      OneGadget::Fetcher.from_build_id(build_id, remote: false)
+      OneGadget::Fetchers.from_build_id(build_id, remote: false)
     end
 
     # Remove hard-to-reach-constraints gadgets according to level

--- a/spec/fetchers/arm_spec.rb
+++ b/spec/fetchers/arm_spec.rb
@@ -2,9 +2,9 @@
 
 require 'one_gadget/fetchers/arm'
 
-describe OneGadget::Fetcher::Arm do
+describe OneGadget::Fetchers::Arm do
   def fetcher(version)
-    OneGadget::Fetcher::Arm.new(data_path("arm-libc-#{version}.so"))
+    OneGadget::Fetchers::Arm.new(data_path("arm-libc-#{version}.so"))
   end
 
   # Terminal-call sites found by disassembling the whole libc and grepping.

--- a/spec/fetchers/base_spec.rb
+++ b/spec/fetchers/base_spec.rb
@@ -4,10 +4,10 @@ require 'one_gadget/emulators/amd64'
 require 'one_gadget/emulators/lambda'
 require 'one_gadget/fetchers/amd64'
 
-describe OneGadget::Fetcher::Base do
+describe OneGadget::Fetchers::Base do
   # Allocate without #initialize so no libc file / objdump is needed; these
   # tests only exercise the arch-independent private helpers of Base.
-  let(:fetcher) { OneGadget::Fetcher::Amd64.allocate }
+  let(:fetcher) { OneGadget::Fetchers::Amd64.allocate }
   let(:processor) { OneGadget::Emulators::Amd64.new }
 
   describe '#check_stack_argv' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ end
 require 'one_gadget/helper'
 require 'one_gadget/logger'
 
-module Helpers
+module Helper
   def hook_logger
     OneGadget::Logger.instance_variable_get(:@logger).reopen($stdout)
     yield
@@ -38,5 +38,5 @@ end
 
 RSpec.configure do |config|
   config.before(:suite) { OneGadget::Helper.color_off! }
-  config.include Helpers
+  config.include Helper
 end


### PR DESCRIPTION
Match the plural fetchers/ directory and the Emulators sibling; a namespace grouping a family of sibling classes is plural (Rails convention). Also align spec_helper's module Helpers -> Helper.