### PR TITLE
Constrain dereferenced pointer args of 'safe' libc calls

### DIFF
--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -40,24 +40,32 @@ module OneGadget
         sp_based_stack
       end
 
+      # Libc calls the emulator accepts without executing, each a syscall wrapper.
+      # +sigprocmask+ and +__sigaction+ each dereference a pointer argument unless it
+      # is NULL (both guard the read with a NULL check and still reach the call on
+      # the NULL path), so +sigprocmask+'s +set+ and +__sigaction+'s +act+ are marked
+      # +:nullable_deref+; +__sigaction+'s +oldact+ must additionally be NULL.
+      # See {Processor#dispatch_safe_call}.
+      SAFE_CALLS = {
+        'sigprocmask' => { 1 => :nullable_deref },
+        '__sigaction' => { 1 => :nullable_deref, 2 => :zero? }
+      }.freeze
+
       private
 
-      # A +bl+/+blx+ call: record the terminal +exec*+ target, silently accept a
-      # known-safe syscall wrapper, or +:fail+ to abort the candidate.
+      # A +bl+/+blx+ call: record the terminal +exec*+ target, accept a known-safe
+      # syscall wrapper, or +:fail+ to abort the candidate.
       def inst_bl(addr)
         # This is the last call.
         return registers[pc] = addr if %w[execve execl posix_spawn].any? { |n| addr.include?(n) }
 
-        # Calls that are always safe because they merely wrap a syscall.
-        checker = {
-          'sigprocmask' => {},
-          '__sigaction' => { 2 => :zero? }
-        }
-        func = checker.keys.find { |n| addr.include?(n) }
-        return if func && checker[func].all? { |idx, sym| check_argument(idx, sym) }
+        dispatch_safe_call(addr, SAFE_CALLS)
+      end
 
-        # unhandled case or checker's condition fails
-        :fail
+      # Libc-relative addresses are known-mapped too; they carry the +$base+ marker
+      # rather than a +pc+-relative one.
+      def mapped_pointer?(obj)
+        super || obj == libc_base.obj.to_s
       end
 
       # The libc load base as a symbolic +$base+ lambda.

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -30,6 +30,7 @@ module OneGadget
         @registers = registers.to_h { |reg| [reg, to_lambda(reg)] }
         @sp = sp
         @constraints = []
+        @deferred_reads = [] # pointer args of safe calls, resolved once emulation ends
         @flags = nil     # last compare, for a following conditional branch
         @pending = nil   # a conditional branch awaiting one-line-ahead resolution
         @sp_based_stack = Hash.new do |h, k|
@@ -97,6 +98,7 @@ module OneGadget
       # @return [Array<String>]
       #   Extra constraints found during execution.
       def constraints
+        finalize_deferred_reads
         return [] if @constraints.empty?
 
         # we have these types:
@@ -131,6 +133,72 @@ module OneGadget
         when :global_var? then global_var?(argument(idx))
         when :zero? then argument(idx).is_a?(Integer) && argument(idx).zero?
         end
+      end
+
+      # Accept a +call+ to a libc function the emulator treats as non-terminal
+      # (a syscall wrapper). +checker+ maps the function name to its per-argument
+      # requirements: an argument index paired with one of
+      # * +:zero?+ / +:global_var?+ - a precondition that must already hold, else
+      #   the candidate is aborted (+:fail+).
+      # * +:nullable_deref+ - the callee dereferences this argument *unless it is
+      #   NULL*, which glibc guards with an explicit NULL check. When the pointer
+      #   isn't already known to be mapped, +<arg> == NULL+ is recorded so the
+      #   callee takes the skip-the-dereference path. Only tag an argument this way
+      #   after confirming the callee both NULL-checks it and still reaches the
+      #   terminal call on the NULL path; an argument dereferenced unconditionally
+      #   cannot be made safe by forcing it NULL (gate it with +:global_var?+, or
+      #   drop the candidate, instead). The check is deferred to
+      #   {#finalize_deferred_reads} because a +<reg>+<imm>+ pointer may only become
+      #   known-mapped once a later store marks +<reg>+ writable.
+      # @return [nil, :fail] +nil+ = call accepted, +:fail+ = abort the candidate.
+      def dispatch_safe_call(addr, checker)
+        func = checker.keys.find { |n| addr.include?(n) }
+        return :fail unless func
+
+        checker[func].each do |idx, req|
+          if req == :nullable_deref
+            @deferred_reads << argument(idx)
+          elsif !check_argument(idx, req)
+            return :fail
+          end
+        end
+        nil
+      end
+
+      # Now that emulation is complete and the full writable set is known, require
+      # each deferred pointer argument to be NULL unless it is already known to
+      # reference mapped memory. Idempotent: the queue is cleared once resolved.
+      def finalize_deferred_reads
+        @deferred_reads.each do |arg|
+          next if deref_safe_pointer?(arg) || writable_pointer?(arg)
+
+          @constraints << [:raw, "#{arg} == NULL"]
+        end
+        @deferred_reads = []
+      end
+
+      # Whether dereferencing +val+ is safe: it is NULL, or a pointer already known
+      # to reference mapped memory (see {#mapped_pointer?}).
+      def deref_safe_pointer?(val)
+        return true if val.is_a?(Integer) && val.zero?
+        return false unless val.is_a?(OneGadget::Emulators::Lambda) && val.deref_count.zero?
+
+        mapped_pointer?(val.obj.to_s)
+      end
+
+      # Whether +val+ points into memory a +writable+ constraint already covers, i.e.
+      # its base register was recorded as a writable store target during emulation.
+      def writable_pointer?(val)
+        return false unless val.is_a?(OneGadget::Emulators::Lambda) && val.deref_count.zero?
+
+        base = val.obj.to_s
+        @constraints.any? { |type, obj| type == :writable && obj.obj.to_s == base }
+      end
+
+      # Whether an address expression names memory known to be mapped: a stack slot
+      # or a libc global. Architectures with an extra base marker override this.
+      def mapped_pointer?(obj)
+        obj.include?(sp) || global_var?(obj)
       end
 
       def register?(reg)

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -12,6 +12,18 @@ module OneGadget
       attr_reader :bp # @return [String] Stack base register.
       attr_reader :bp_based_stack # @return [Hash{Integer => OneGadget::Emulators::Lambda}] Stack content based on bp.
 
+      # Libc calls the emulator accepts without executing, each a syscall wrapper.
+      # +sigprocmask+ dereferences its +set+ argument (arg 1) unless it is NULL (which
+      # it NULL-checks), so +set+ is marked +:nullable_deref+; +__sigaction+'s
+      # dereferenced +act+ (arg 1) is required to be a libc global instead.
+      # See {Processor#dispatch_safe_call}.
+      SAFE_CALLS = {
+        'sigprocmask' => { 1 => :nullable_deref },
+        '__close' => {},
+        'unsetenv' => { 0 => :global_var? },
+        '__sigaction' => { 1 => :global_var?, 2 => :zero? }
+      }.freeze
+
       # Constructor for a x86 processor.
       def initialize(registers, sp, bp, pc)
         super(registers, sp)
@@ -266,25 +278,12 @@ module OneGadget
       # yap, nop
       def inst_nop(*); end
 
-      # Handle some valid calls.
-      # For example, +sigprocmask+ will always be a valid call
-      # because it just invokes syscall.
+      # TODO: handle some registers would be fucked after call
       def inst_call(addr)
         # This is the last call
         return registers[pc] = addr if %w[execve execl posix_spawn].any? { |n| addr.include?(n) }
 
-        # TODO: handle some registers would be fucked after call
-        checker = {
-          'sigprocmask' => {},
-          '__close' => {},
-          'unsetenv' => { 0 => :global_var? },
-          '__sigaction' => { 1 => :global_var?, 2 => :zero? }
-        }
-        func = checker.keys.find { |n| addr.include?(n) }
-        return if func && checker[func].all? { |idx, sym| check_argument(idx, sym) }
-
-        # unhandled case or checker's condition fails
-        :fail
+        dispatch_safe_call(addr, SAFE_CALLS)
       end
 
       def add_writable(dst)

--- a/spec/one_gadget_aarch64_spec.rb
+++ b/spec/one_gadget_aarch64_spec.rb
@@ -11,18 +11,39 @@ describe 'one_gadget_aarch64' do
     it 'libc-2.23' do
       path = data_path('aarch64-libc-2.23.so')
       expect(OneGadget.gadgets(file: path, force_file: true, level: 1))
-        .to eq [0x3d6c4, 0x3d6cc, 0x3d6d0, 0x3d6d4, 0x3d6dc, 0x3d718,
+        .to eq [0x3d6c4, 0x3d6cc, 0x3d6d0, 0x3d6d4, 0x3d6d8, 0x3d718,
                 0x60c1c, 0x60c20, 0x9b9e0, 0x9b9e4, 0x9bc5c]
     end
 
     it 'libc-2.24' do
       path = data_path('aarch64-libc-2.24.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3c92c, 0x3c934, 0x3c970]
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3c92c, 0x3c930, 0x3c970]
     end
 
     it 'libc-2.27' do
       path = data_path('aarch64-libc-2.27.so')
       expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f160, 0x63e90, 0xa32e8]
+    end
+
+    # do_system reaches execve via a sigprocmask(set) call that dereferences its
+    # `set` argument; a gadget landing before that call must keep `set` NULL.
+    it 'constrains the sigprocmask set argument to NULL' do
+      path = data_path('aarch64-libc-2.24.so')
+      gadgets = OneGadget.gadgets(file: path, force_file: true, details: true)
+      before_call = gadgets.find { |g| g.offset == 0x3c92c }
+      after_call = gadgets.find { |g| g.offset == 0x3c970 }
+      expect(before_call.constraints).to include('x21 == NULL')
+      expect(after_call.constraints).not_to include('x21 == NULL')
+    end
+
+    # do_system's sigaction(act) also dereferences its `act` argument. The entry
+    # that skips act's setup (0x3c934) needs the extra `x1 == NULL`, so it is
+    # dominated by the entry that sets act up (0x3c930) and drops out.
+    it 'constrains the sigaction act argument, dropping the dominated entry' do
+      path = data_path('aarch64-libc-2.24.so')
+      offsets = OneGadget.gadgets(file: path, force_file: true)
+      expect(offsets).to include(0x3c930)
+      expect(offsets).not_to include(0x3c934)
     end
 
     # glibc 2.43 no longer exposes a straight-line execve("/bin/sh") gadget; the

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -18,7 +18,7 @@ describe 'one_gadget_amd64' do
 
     it 'libc-2.24' do
       path = data_path('libc-2.24-8cba3297f538691eb1875be62986993c004f3f4d.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f356, 0x3f3aa, 0xd67e5]
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f3aa, 0xb8a38, 0xd67e5]
       expect(one_gadget(path)).to eq OneGadget.gadgets(file: path)
     end
 
@@ -30,7 +30,8 @@ describe 'one_gadget_amd64' do
 
     it 'libc-2.27' do
       path = data_path('libc-2.27-b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x4f2be, 0x4f2c5, 0x4f322, 0x10a38c]
+      expect(OneGadget.gadgets(file: path, force_file: true))
+        .to eq [0x4f322, 0xe569f, 0xe5858, 0xe585f, 0xe5863, 0x10a38c]
       expect(one_gadget(path)).to eq OneGadget.gadgets(file: path)
     end
 

--- a/spec/one_gadget_i386_spec.rb
+++ b/spec/one_gadget_i386_spec.rb
@@ -11,24 +11,23 @@ describe 'one_gadget_i386' do
     it 'libc-2.19' do
       path = data_path('libc-2.19-fd51b20e670e9a9f60dc3b06dc9761fb08c9358b.so')
       expect(OneGadget.gadgets(file: path,
-                               force_file: true)).to eq [0x3fd17, 0x3fd1e, 0x3fd27,
-                                                         0x64c60, 0x64c64, 0x64c6a, 0x64c6e]
+                               force_file: true)).to eq [0x3fd27, 0x64c60, 0x64c64, 0x64c6a, 0x64c6e]
     end
 
     it 'libc-2.23' do
-      ans = [0x3ac5c, 0x3ac5e, 0x3ac62, 0x3ac69, 0x5fbc5, 0x5fbc6]
+      ans = [0x3ac69, 0x5fbc5, 0x5fbc6]
       path = data_path('libc-2.23-926eb99d49cab2e5622af38ab07395f5b32035e9.so')
       expect(OneGadget.gadgets(file: path, force_file: true)).to eq ans
     end
 
     it 'libc-2.26' do
-      ans = [0x3cc2f, 0x3cc31, 0x3cc35, 0x3cc3c, 0x66e7f, 0x66e80, 0x132fbe, 0x132fbf]
+      ans = [0x3cc3c, 0x66e7f, 0x66e80, 0x132fbe, 0x132fbf]
       path = data_path('libc-2.26-f65648a832414f2144ce795d75b6045a1ec2e252.so')
       expect(OneGadget.gadgets(file: path, force_file: true)).to eq ans
     end
 
     it 'libc-2.27' do
-      ans = [0x3cbea, 0x3cbec, 0x3cbf0, 0x3cbf7, 0x6729f, 0x672a0, 0x13573e, 0x13573f]
+      ans = [0x3cbf7, 0x6729f, 0x672a0, 0x13573e, 0x13573f]
       path = data_path('libc-2.27-63b3d43ad45e1b0f601848c65b067f9e9b40528b.so')
       expect(OneGadget.gadgets(file: path, force_file: true)).to eq ans
     end


### PR DESCRIPTION
The emulator skips some libc calls (sigprocmask, __sigaction) as safe syscall wrappers, but each dereferences a pointer argument unless it is NULL (glibc guards each with a NULL check). Gadgets reaching such a call with an uncontrolled pointer were emitted without the needed constraint.

Add a shared dispatch_safe_call in Processor with a :nullable_deref arg requirement (the callee derefs the arg unless it is NULL, and still reaches the call on the NULL path). The check is deferred to after emulation (finalize_deferred_reads) so a reg+imm pointer that a later store marks writable is recognised as mapped and not over-constrained; otherwise '<arg> == NULL' is emitted.

Applied to sigprocmask's set on all arches and __sigaction's act on ARM/AArch64 (x86 already gates act via :global_var?). Purely additive at level 1; the default level 0 re-ranks, and trim_gadgets now correctly drops a harder entry in favour of an easier sibling that dominates it.