### PR TITLE
Halt emulation at the terminal exec* call

### DIFF
--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -40,7 +40,9 @@ module OneGadget
         sp_based_stack
       end
 
-      # Libc calls the emulator accepts without executing, each a syscall wrapper.
+      # Libc calls the emulator accepts without executing: syscall wrappers, and
+      # +posix_spawn+'s setup helpers (matched by prefix), which precede the real
+      # call and are side-effect-free for gadget purposes.
       # +sigprocmask+ and +__sigaction+ each dereference a pointer argument unless it
       # is NULL (both guard the read with a NULL check and still reach the call on
       # the NULL path), so +sigprocmask+'s +set+ and +__sigaction+'s +act+ are marked
@@ -48,7 +50,9 @@ module OneGadget
       # See {Processor#dispatch_safe_call}.
       SAFE_CALLS = {
         'sigprocmask' => { 1 => :nullable_deref },
-        '__sigaction' => { 1 => :nullable_deref, 2 => :zero? }
+        '__sigaction' => { 1 => :nullable_deref, 2 => :zero? },
+        'posix_spawnattr_' => {},
+        'posix_spawn_file_actions_' => {}
       }.freeze
 
       private
@@ -56,8 +60,7 @@ module OneGadget
       # A +bl+/+blx+ call: record the terminal +exec*+ target, accept a known-safe
       # syscall wrapper, or +:fail+ to abort the candidate.
       def inst_bl(addr)
-        # This is the last call.
-        return registers[pc] = addr if %w[execve execl posix_spawn].any? { |n| addr.include?(n) }
+        return reach_terminal_call(addr) if terminal_call?(addr)
 
         dispatch_safe_call(addr, SAFE_CALLS)
       end

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -41,6 +41,33 @@ module OneGadget
         end
       end
 
+      # Function names whose call ends a gadget: the real +exec*+ entry points.
+      # Deliberately excludes the +posix_spawn+ setup helpers
+      # (+posix_spawnattr_*+, +posix_spawn_file_actions_*+), which merely share the
+      # +posix_spawn+ prefix.
+      # @example matches +posix_spawn+, +execve+, +execveat+, +execlp+; not +posix_spawnattr_init+
+      TERMINAL_CALL_RE = /\A(?:posix_spawnp?|exec(?:ve|l|v)[a-z]*)\z/
+
+      # Whether +addr+ calls a terminal +exec*+ entry point (see
+      # {#reach_terminal_call}). Matches the resolved symbol name exactly so a
+      # setup helper isn't mistaken for the call it precedes.
+      # @param [String] addr The call target, e.g. +"10c7d0 <posix_spawn@@GLIBC_2.15>"+.
+      # @return [Boolean]
+      def terminal_call?(addr)
+        name = addr[/<([^@>]+)/, 1]
+        !name.nil? && TERMINAL_CALL_RE.match?(name)
+      end
+
+      # Record a reached terminal +exec*+ call as the gadget's effect and stop
+      # emulating: it is the gadget's goal, and any following instruction would
+      # clobber the argument registers that {#resolve} reads to describe it.
+      # @param [String] addr The call target.
+      # @return [Symbol] +:fail+, the sentinel {#process!} maps to "stop".
+      def reach_terminal_call(addr)
+        registers[pc] = addr
+        :fail
+      end
+
       # Parse one command into instruction and arguments.
       # @param [String] cmd One line of result of objdump.
       # @return [(Instruction, Array<String>)]

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -12,7 +12,9 @@ module OneGadget
       attr_reader :bp # @return [String] Stack base register.
       attr_reader :bp_based_stack # @return [Hash{Integer => OneGadget::Emulators::Lambda}] Stack content based on bp.
 
-      # Libc calls the emulator accepts without executing, each a syscall wrapper.
+      # Libc calls the emulator accepts without executing: syscall wrappers, and
+      # +posix_spawn+'s setup helpers (matched by prefix), which precede the real
+      # call and are side-effect-free for gadget purposes.
       # +sigprocmask+ dereferences its +set+ argument (arg 1) unless it is NULL (which
       # it NULL-checks), so +set+ is marked +:nullable_deref+; +__sigaction+'s
       # dereferenced +act+ (arg 1) is required to be a libc global instead.
@@ -21,7 +23,9 @@ module OneGadget
         'sigprocmask' => { 1 => :nullable_deref },
         '__close' => {},
         'unsetenv' => { 0 => :global_var? },
-        '__sigaction' => { 1 => :global_var?, 2 => :zero? }
+        '__sigaction' => { 1 => :global_var?, 2 => :zero? },
+        'posix_spawnattr_' => {},
+        'posix_spawn_file_actions_' => {}
       }.freeze
 
       # Constructor for a x86 processor.
@@ -280,8 +284,7 @@ module OneGadget
 
       # TODO: handle some registers would be fucked after call
       def inst_call(addr)
-        # This is the last call
-        return registers[pc] = addr if %w[execve execl posix_spawn].any? { |n| addr.include?(n) }
+        return reach_terminal_call(addr) if terminal_call?(addr)
 
         dispatch_safe_call(addr, SAFE_CALLS)
       end

--- a/spec/emulators/arm_spec.rb
+++ b/spec/emulators/arm_spec.rb
@@ -133,11 +133,13 @@ describe OneGadget::Emulators::Arm do
     end
 
     it 'bl / blx to terminal and pass-through calls' do
-      expect(@processor.process('0: bl 70160 <execl@@GLIBC_2.4>')).to be true
+      # A terminal exec* call records the effect (pc) and halts emulation, so any
+      # following instruction can't clobber the call's argument registers.
+      expect(@processor.process('0: bl 70160 <execl@@GLIBC_2.4>')).to be false
       expect(@processor.registers['pc'].to_s).to include 'execl'
 
       other = described_class.new
-      expect(other.process('0: blx 88990 <execve@@GLIBC_2.4>')).to be true
+      expect(other.process('0: blx 88990 <execve@@GLIBC_2.4>')).to be false
       expect(other.registers['pc'].to_s).to include 'execve'
 
       # sigprocmask is always safe; __sigaction needs arg2 (r2) == 0.
@@ -146,8 +148,10 @@ describe OneGadget::Emulators::Arm do
       expect(@processor.process('c: bl 24754 <__sigaction@@GLIBC_2.4>')).to be true
       @processor.process('10: mov r2, r0')
       expect(@processor.process('14: bl 24754 <__sigaction@@GLIBC_2.4>')).to be false
+      # a posix_spawn setup helper is a side-effect-free pass-through (SAFE_CALLS prefix).
+      expect(@processor.process('18: bl 10c690 <posix_spawnattr_init@@GLIBC_2.4>')).to be true
       # an unhandled call aborts the candidate.
-      expect(@processor.process('18: bl 12345 <free@@GLIBC_2.4>')).to be false
+      expect(@processor.process('1c: bl 12345 <free@@GLIBC_2.4>')).to be false
     end
 
     it 'flag-only instructions have no effect' do

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -16,6 +16,14 @@ describe 'one_gadget_amd64' do
                 0xe654d, 0xe6552, 0xe6557, 0xe6670, 0xe6677, 0xe6685, 0xe668a, 0xe668f, 0xe6697, 0xe669e, 0xe66bd]
     end
 
+    # Regression: a candidate that ran past its terminal execve into the stack-guard
+    # epilogue used to yield spurious gadgets whose fs:/[rax-8] constraints crashed
+    # score computation at the default level. Halting at the terminal call drops them.
+    it 'libc-2.23 (level 0 does not crash on stale-state gadgets)' do
+      path = data_path('libc-2.23-60131540dadc6796cab33388349e6e4e68692053.so')
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x4526a, 0xef6c4, 0xf0567]
+    end
+
     it 'libc-2.24' do
       path = data_path('libc-2.24-8cba3297f538691eb1875be62986993c004f3f4d.so')
       expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f3aa, 0xb8a38, 0xd67e5]
@@ -38,11 +46,10 @@ describe 'one_gadget_amd64' do
     it 'libc-2.31' do
       path = data_path('libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so')
       expect(OneGadget.gadgets(file: path, force_file: true,
-                               level: 1)).to eq [0x51df8, 0x51e2b, 0x51e32, 0x51e39, 0x51e40, 0x51e45, 0x51e55,
-                                                 0x51e5a, 0x51e5d, 0x51e62, 0x51e65, 0x840c3, 0x84165, 0x8416c,
-                                                 0x84173, 0x84176, 0x8417b, 0x84180, 0x8418c, 0x84192, 0x84199,
-                                                 0x841a0, 0x841a3, 0xe3b2e, 0xe3b31, 0xe3b34, 0xe3d23, 0xe3d26,
-                                                 0xe3d88, 0xe3d92, 0xe3d99, 0xe3da0, 0xe3dd7, 0xe3de1, 0xe3de5,
+                               level: 1)).to eq [0x51df8, 0x51e2b, 0x51e32, 0x51e39, 0x51e40, 0x51e45, 0x51e55, 0x51e5a,
+                                                 0x51e5d, 0x51e62, 0x84165, 0x8416c, 0x84173, 0x84176, 0x8417b, 0x84180,
+                                                 0x8418c, 0x84192, 0x84199, 0x841a0, 0xe3b2e, 0xe3b31, 0xe3b34, 0xe3d23,
+                                                 0xe3d26, 0xe3d88, 0xe3d92, 0xe3d99, 0xe3da0, 0xe3dd7, 0xe3de1, 0xe3de5,
                                                  0xe3ded, 0x1075e7, 0x1075f1, 0x107cea]
       expect(OneGadget.gadgets(file: path)).to eq [0xe3b2e, 0xe3b31, 0xe3b34]
     end


### PR DESCRIPTION
A candidate is emulated as every suffix ending in a call to exec*. The call handler matched any execve/execl/posix_spawn *substring*, set pc, and kept emulating -- so a suffix could run past the real call into the epilogue, where later instructions clobbered the argument registers that resolve() reads (and posix_spawnattr_destroy re-matched the substring, re-setting pc). This produced gadgets with wrong arguments: amd64 posix_spawn pids mislabeled (rbp instead of rdi), arm envp read as environ instead of the real register, and libc-2.23 stack-guard-epilogue gadgets whose fs:/[rax-8] constraints crashed score at the default level.

Halt at the terminal call (matched precisely on the resolved symbol name) so arguments reflect the call site. posix_spawn's setup helpers (posix_spawnattr_*, posix_spawn_file_actions_*), which precede the real call and are side-effect-free for gadget purposes, become side-effect-free SAFE_CALLS entries (matched by prefix) instead of aborting the candidate.