### PR TITLE
amd64: concretize rip-relative operands to $base+offset

### DIFF
--- a/lib/one_gadget/emulators/amd64.rb
+++ b/lib/one_gadget/emulators/amd64.rb
@@ -32,6 +32,74 @@ module OneGadget
         when 5 then registers['r9']
         end
       end
+
+      private
+
+      # Resolve a data-flow line's rip-relative operand to +$base+<file offset>+
+      # (base-relative like arm's +adrp+, not instruction-relative +rip+disp+),
+      # taking the offset from objdump's resolution comment and dropping it.
+      # A compare/branch line is returned untouched, so the branch-aware search
+      # still sees exactly what objdump emitted.
+      # @example
+      #   concretize_rip('d67f1: lea rdi,[rip+0x8ab61]  # 161359 <sym>')
+      #   #=> 'd67f1: lea rdi,[$base+0x161359]'
+      #   concretize_rip('51de5: cmp [rip+0x19c733],0x1  # 1ee520 <sym>')
+      #   #=> unchanged (a compare)
+      def concretize_rip(cmd)
+        resolved = cmd[/#\s*([0-9a-f]+)/, 1]
+        return cmd unless resolved && cmd.include?('rip')
+        return cmd if compare_or_branch?(mnemonic(cmd))
+
+        cmd.sub(/(\[?)rip[+-]0x[0-9a-f]+(\]?)/) { "#{Regexp.last_match(1)}$base+0x#{resolved}#{Regexp.last_match(2)}" }
+           .sub(/\s*#.*\z/, '')
+      end
+
+      # Whether the branch-aware search steers +mnem+, rather than {#concretize_rip}
+      # rewriting it as a data-flow instruction.
+      # @example
+      #   compare_or_branch?('cmp')  #=> true
+      #   compare_or_branch?('je')   #=> true
+      #   compare_or_branch?('lea')  #=> false
+      def compare_or_branch?(mnem)
+        COMPARES.key?(mnem) || branch_mnem?(mnem)
+      end
+
+      # The libc load base as a symbolic lambda (cf. {ArmFamily#libc_base}).
+      # @example
+      #   libc_base.to_s  #=> '$base'
+      def libc_base
+        @libc_base ||= OneGadget::Emulators::Lambda.new('$base')
+      end
+
+      # Build a lambda for a concretized +$base+<off>+ operand (optionally
+      # bracketed); anything else falls back to {Processor#arg_to_lambda}.
+      # @example
+      #   arg_to_lambda('$base+0x161359').to_s    #=> '$base+0x161359'
+      #   arg_to_lambda('[$base+0x1ebeb0]').to_s  #=> '[$base+0x1ebeb0]'
+      #   arg_to_lambda('rdi')                    # not a $base operand -> super
+      def arg_to_lambda(arg)
+        m = arg.match(/\A(\[*)\$base\+0x([0-9a-f]+)(\]*)\z/)
+        return super unless m
+
+        lmda = libc_base + m[2].to_i(16)
+        m[1].size.times { lmda = lmda.deref }
+        lmda
+      end
+
+      # Recognise the concretized libc-global marker as a global variable.
+      # @example
+      #   global_var?('$base+0x100')  #=> true
+      #   global_var?('rax')          #=> false
+      def global_var?(obj)
+        super || obj.to_s.include?(libc_base.obj)
+      end
+
+      # A concretized libc global is a fixed target, so it needs no writable constraint.
+      # @example
+      #   needs_writable?(arg_to_lambda('$base+0x100'))  #=> false
+      def needs_writable?(lmda)
+        super && lmda.obj != libc_base.obj
+      end
     end
   end
 end

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -48,6 +48,7 @@ module OneGadget
       # @return [Boolean]
       #   If successfully processed.
       def process!(cmd)
+        cmd = concretize_rip(cmd)
         resolve_pending_branch(cmd)
         mnem = mnemonic(cmd)
         return handle_compare(COMPARES[mnem], cmd) if COMPARES.key?(mnem)
@@ -129,6 +130,11 @@ module OneGadget
           o.gsub(/\b(XMMWORD|QWORD|DWORD|WORD|BYTE|PTR)\b/, '').strip.sub(/\s*<.*>\z/, '')
         end
       end
+
+      # Arch-specific hook to rewrite a line's operands before it is processed. A
+      # no-op here; amd64 overrides it to resolve rip-relative operands (i386 has
+      # no rip-relative addressing, so it keeps the no-op). See {Amd64#concretize_rip}.
+      def concretize_rip(cmd) = cmd
 
       # The (direct) target address of a jump line.
       def jump_target(cmd)
@@ -291,10 +297,17 @@ module OneGadget
 
       def add_writable(dst)
         lmda = arg_to_lambda(dst).ref!
-        # pc-relative addresses should be writable
-        return if lmda.obj == pc
+        @constraints << [:writable, lmda] if needs_writable?(lmda)
+      end
 
-        @constraints << [:writable, lmda]
+      # Whether a store through +lmda+ imposes a "must be writable" constraint. A
+      # fixed libc-internal target does not: pc-relative here, plus amd64's
+      # concretized +$base+ globals.
+      # @example (pc is +rip+)
+      #   needs_writable?(arg_to_lambda('rax'))  #=> true   # an attacker register
+      #   needs_writable?(arg_to_lambda('rip'))  #=> false  # pc-relative libc address
+      def needs_writable?(lmda)
+        lmda.obj != pc
       end
 
       def to_lambda(reg)

--- a/lib/one_gadget/fetchers/amd64.rb
+++ b/lib/one_gadget/fetchers/amd64.rb
@@ -30,11 +30,11 @@ module OneGadget
       end
 
       def str_bin_sh?(str)
-        str.include?('rip+0x') # && str.include?(bin_sh_hex)
+        str.include?('$base') && str.include?(bin_sh_hex)
       end
 
       def global_var?(str)
-        str.include?('rip')
+        str.include?('$base')
       end
     end
   end

--- a/spec/emulators/amd64_spec.rb
+++ b/spec/emulators/amd64_spec.rb
@@ -47,7 +47,10 @@ describe OneGadget::Emulators::Amd64 do
       EOS
       gadget.each_line { |s| @processor.process(s) }
       expect(@processor.registers['rsi'].to_s).to eq 'rsp+0x70'
-      expect(@processor.registers['rdx'].to_s).to eq '[[rip+0x2c16b4]]'
+      # rip-relative operands are concretized to $base+<file offset> (from objdump's
+      # resolution comment), so a libc global carries the $base marker.
+      expect(@processor.registers['rdi'].to_s).to eq '$base+0x161359'
+      expect(@processor.registers['rdx'].to_s).to eq '[[$base+0x397ea0]]'
     end
 
     it 'mov' do

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -54,6 +54,15 @@ describe 'one_gadget_amd64' do
       expect(OneGadget.gadgets(file: path)).to eq [0xe3b2e, 0xe3b31, 0xe3b34]
     end
 
+    # rip-relative libc globals are concretized to $base+<off>, so the do_system
+    # "-c" separator resolves to its string content (like aarch64/arm).
+    it 'libc-2.31 resolves the do_system "-c" argv operand' do
+      path = data_path('libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so')
+      gadget = OneGadget.gadgets(file: path, force_file: true, level: 1, details: true)
+                        .find { |g| g.offset == 0x51df8 }
+      expect(gadget.constraints).to include('{"sh", "-c", rbx, NULL} is a valid argv')
+    end
+
     it 'not ELF' do
       expect { hook_logger { OneGadget.gadgets(file: __FILE__) } }.to output(<<-EOS).to_stdout
 [OneGadget] ArgumentError: Not an ELF file, expected glibc as input


### PR DESCRIPTION
Rewrite a data-flow instruction's rip-relative operand to $base+<file offset> (from objdump's resolution comment), so a libc global carries the $base marker like arm's adrp -- not the ambiguous, instruction-relative rip+disp. Compare and branch operands are left untouched so the branch-aware search is unaffected.

This lets str_bin_sh? check the actual /bin/sh offset (dropping a false positive that any rip-relative arg0 was accepted as "/bin/sh"), and lets the shared argv resolver render do_system's "-c"/"--" separators as their string content on amd64.