### PR TITLE
aarch64: track frame-pointer (x29) stack for argv resolution

### DIFF
--- a/lib/one_gadget/emulators/aarch64.rb
+++ b/lib/one_gadget/emulators/aarch64.rb
@@ -17,6 +17,7 @@ module OneGadget
         # Constant registers
         %w[xzr wzr].each { |r| @registers[r] = 0 }
         @pc = 'pc'
+        setup_frame_pointer('x29') # track argv/data staged off the frame pointer
       end
 
       # @see OneGadget::Emulators::X86#process!
@@ -119,10 +120,11 @@ module OneGadget
         raise_unsupported('stp', reg1, reg2, dst) unless reg64?(reg1) && reg64?(reg2)
 
         dst_l = arg_to_lambda(dst).ref!
-        if dst_l.obj == sp && dst_l.deref_count.zero?
+        stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
+        if stack
           cur_top = dst_l.evaluate(eval_dict)
-          sp_based_stack[cur_top] = registers[reg1]
-          sp_based_stack[cur_top + size_t] = registers[reg2]
+          stack[cur_top] = registers[reg1]
+          stack[cur_top + size_t] = registers[reg2]
         else
           # Don't know where it points; just require it be writable (as inst_str does).
           add_writable(dst_l)
@@ -136,10 +138,11 @@ module OneGadget
         raise_unsupported('str', src, dst, index) unless OneGadget::Helper.integer?(index)
 
         dst_l = arg_to_lambda(dst).ref!
-        # Only stores on stack.
-        if dst_l.obj == sp && dst_l.deref_count.zero?
+        # Only stores on stack (sp- or frame-pointer-relative).
+        stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
+        if stack
           cur_top = dst_l.evaluate(eval_dict)
-          sp_based_stack[cur_top] = registers[src]
+          stack[cur_top] = registers[src]
         else
           # Unlike the stack case, don't know where to save the value.
           # Simply add a constraint.

--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -28,16 +28,49 @@ module OneGadget
       # its own {X86::COMPARES}.
       COMPARES = { 'cmp' => :sub, 'cmn' => :add, 'tst' => :and }.freeze
 
-      # The sp-based stack that +obj+ addresses, or +nil+ when +obj+ isn't sp-relative.
+      # Frame-pointer register whose relative stores are tracked, or +nil+ when this
+      # arch tracks none. Enabled via {#setup_frame_pointer} (mirrors x86's +bp+).
+      attr_reader :bp
+
+      # @return [Hash{Integer => Lambda}, nil] Stack content based on {#bp}, or nil.
+      attr_reader :bp_based_stack
+
+      # Enable frame-pointer stack tracking with +bp+ as the frame register (so a
+      # gadget that stages data at +[bp+imm]+ -- e.g. an argv array off +x29+ -- is
+      # recovered instead of collapsing to a bare +writable:+). Nil disables it,
+      # leaving the arch +sp+-only. Call from the arch initializer after +super+.
+      def setup_frame_pointer(bp)
+        @bp = bp
+        return if bp.nil?
+
+        @bp_based_stack = Hash.new do |h, k|
+          h[k] = OneGadget::Emulators::Lambda.new(bp).tap do |lmda|
+            lmda.immi = k
+            lmda.deref!
+          end
+        end
+      end
+
+      # The stack that +obj+ addresses -- +sp+-based, {#bp}-based, or +nil+ when
+      # +obj+ isn't stack-relative.
       # @param [String, Lambda] obj A lambda object or its string.
       # @return [Hash{Integer => Lambda}, nil]
       # @example
       #   get_corresponding_stack('sp+0x10') #=> sp_based_stack
+      #   get_corresponding_stack('x29+0x40') #=> bp_based_stack (aarch64)
       #   get_corresponding_stack('x21')     #=> nil
       def get_corresponding_stack(obj)
-        return nil unless obj.to_s.include?(sp)
+        s = obj.to_s
+        return sp_based_stack if s.include?(sp)
+        return bp_based_stack if bp && s.include?(bp)
 
-        sp_based_stack
+        nil
+      end
+
+      # Resolve +sp+- and (when tracked) {#bp}-relative operands to their offset;
+      # the base {Processor#eval_dict} covers only +sp+ (cf. x86).
+      def eval_dict
+        bp ? { sp => 0, bp => 0 } : { sp => 0 }
       end
 
       # Libc calls the emulator accepts without executing: syscall wrappers, and

--- a/spec/one_gadget_aarch64_spec.rb
+++ b/spec/one_gadget_aarch64_spec.rb
@@ -22,7 +22,17 @@ describe 'one_gadget_aarch64' do
 
     it 'libc-2.27' do
       path = data_path('aarch64-libc-2.27.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f160, 0x63e90, 0xa32e8]
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f160, 0x63e90, 0xa32e8, 0xa32ec]
+    end
+
+    it 'constrains argv[1] for an argv built off the frame pointer' do
+      path = data_path('aarch64-libc-2.27.so')
+      gadget = OneGadget.gadgets(file: path, force_file: true, details: true, level: 1)
+                        .find { |g| g.offset == 0xa3234 }
+      # execve("/bin/sh", x29+0x40, ...): the code stores x0 as argv[1] in the
+      # frame, so x0 must be NULL (or a valid arg) -- not an opaque "valid argv".
+      expect(gadget.effect).to eq 'execve("/bin/sh", x29+0x40, x2)'
+      expect(gadget.constraints).to include('x0 == NULL || {"/bin/sh", x0, NULL} is a valid argv')
     end
 
     # do_system reaches execve via a sigprocmask(set) call that dereferences its


### PR DESCRIPTION
The emulator tracked only sp-relative stores, so an argv array staged off the frame pointer (stp x1,x0,[x29,#64] => {"/bin/sh", x0, NULL}) collapsed to an opaque 'x29+0x40 is a valid argv', hiding that argv[1] = x0 must be NULL. Mirror x86's bp_based_stack: add frame-pointer stack tracking (x29 on aarch64; arm unchanged), so these gadgets emit the precise 'x0 == NULL || {"/bin/sh", x0, NULL} is a valid argv' -- the same shape sp-relative and amd64/rbp argv already get.

Harmonizes an inconsistency (the sp-relative twin already had the precise form); the trimmer then dedups the now-identical gadgets. Found via Aletheia on aarch64-2.27 (Finding 4).