### PR TITLE
arm: track writes through any register in str, not just sp

### DIFF
--- a/lib/one_gadget/emulators/arm.rb
+++ b/lib/one_gadget/emulators/arm.rb
@@ -177,11 +177,15 @@ module OneGadget
         raise_unsupported('str', src, dst, index) unless OneGadget::Helper.integer?(index)
 
         dst_l = arg_to_lambda(resolve_int_regs(dst)).ref!
-        if dst_l.obj == sp && dst_l.deref_count.zero?
-          sp_based_stack[dst_l.evaluate(eval_dict)] = registers[src]
-        else
-          add_writable(dst_l)
-        end
+        # A tracked register: sp/bp, or any other register a write has been
+        # staged through this candidate (see Processor#reg_based_stack).
+        stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
+        stack[dst_l.immi] = registers[src] if stack
+        # sp/bp are always writable: no constraint needed. Any OTHER register
+        # might not be, so still record the requirement even when the write IS
+        # also tracked for later precise resolution -- the fetcher drops this if
+        # that resolution ends up superseding it.
+        add_writable(dst_l) unless [sp_based_stack, bp_based_stack].include?(stack)
 
         index = Integer(index)
         return unless dst.end_with?('!') || index.nonzero?

--- a/lib/one_gadget/fetchers/arm.rb
+++ b/lib/one_gadget/fetchers/arm.rb
@@ -109,15 +109,18 @@ module OneGadget
         cmds.each_with_object(emu) { |cmd, obj| break obj unless obj.process(cmd) }
       end
 
-      # A GOT base register seeded from the prologue is a runtime precondition: it
-      # must hold the libc GOT base for the candidate to reach +environ+. Surface
-      # that as a constraint (mirroring i386's +<reg> is the GOT address of libc+)
-      # whenever a GOT-resolved global actually made it into the effect. Seeding
-      # only ever primes registers set up *before* the window, so a gadget that
-      # establishes the base itself carries no such constraint.
+      # A GOT base register seeded from the prologue is a runtime precondition,
+      # independent of what its load is *for*: the +[rB, rX]+ dereference itself
+      # faults on a wrong base, whether the value it fetches is +environ+ or
+      # something unrelated to the effect entirely (e.g. a stack-protector guard
+      # read). Surface it as a constraint (mirroring i386's +<reg> is the GOT
+      # address of libc+) whenever the candidate actually walked past such a
+      # dereference. Seeding only ever primes registers set up *before* the
+      # window, so a gadget that establishes the base itself carries no such
+      # constraint.
       def resolve(processor)
         res = super
-        return res if res.nil? || !res[:effect].include?('environ')
+        return res if res.nil? || @got_base_regs.empty?
 
         @got_base_regs.each do |reg|
           res[:constraints].unshift("#{reg} is the GOT address of libc")

--- a/spec/one_gadget_arm_spec.rb
+++ b/spec/one_gadget_arm_spec.rb
@@ -47,6 +47,16 @@ describe 'one_gadget_arm' do
       expect(gadget.constraints).to include('[r1] == 0x0')
     end
 
+    it 'constrains a GOT base register even when its load is for something other than environ' do
+      path = data_path('arm-libc-2.27.so')
+      gadget = OneGadget.gadgets(file: path, force_file: true, level: 1, details: true)
+                        .find { |g| g.offset == 0x73f2c }
+      # 0x73f2c reads a libc global (the stack-protector guard) via r3 as the GOT
+      # base, not environ -- the constraint must still surface: a wrong r3 faults
+      # on that load regardless of what it was for.
+      expect(gadget.constraints).to include('r3 is the GOT address of libc')
+    end
+
     it 'resolves environ through the GOT base register and constrains it' do
       path = data_path('arm-libc-2.23.so')
       gadgets = OneGadget.gadgets(file: path, force_file: true, details: true)
@@ -55,6 +65,19 @@ describe 'one_gadget_arm' do
       # Reaching environ needs the GOT base in a register (loaded in the prologue,
       # outside the window); it must be pinned, like i386's GOT-base constraint.
       expect(gadget.constraints).to include('r8 is the GOT address of libc')
+    end
+
+    it 'resolves argv through a register written via str, not just sp/bp' do
+      path = data_path('arm-libc-2.27.so')
+      gadgets = OneGadget.gadgets(file: path, force_file: true, level: 1, details: true)
+      # 0x73f3a/0x73f96 build argv on the stack via `str reg, [r7, #imm]`; the
+      # array's first element (r7's own target) must be tracked so r0 -- an
+      # untracked entry the code writes into the array too -- surfaces as a
+      # real precondition, not an opaque "r7 is a valid argv".
+      [0x73f3a, 0x73f96].each do |offset|
+        gadget = gadgets.find { |g| g.offset == offset }
+        expect(gadget.constraints).to include('r0 == NULL || {"/bin/sh", r0, NULL} is a valid argv')
+      end
     end
 
     it 'finds posix_spawn (do_system) gadgets with stack-passed argv/envp' do


### PR DESCRIPTION
inst_str only tracked writes into sp_based_stack, unlike every other arch's Finding-6-generalized inst_stp/inst_str (aarch64) or inst_mov (x86): a str through any other register -- e.g. the frame-pointer-like r7 used to build argv on the stack -- fell straight to add_writable, losing the write entirely instead of feeding get_corresponding_stack's per-register tracking. Two arm-2.27 gadgets (0x73f3a/0x73f96) built argv as {"/bin/sh", r0, NULL} with r0 an untracked incoming register; Aletheia confirmed it lands readable-but-empty under default fill, so sh gets invoked as `sh ""` and exits immediately instead of staying interactive -- the same failure shape as the earlier lea-alias fix, just via str instead of a computed alias.

Also broadens arm.rb's GOT-base-register constraint: it only fired when the effect textually contained "environ", but the underlying [rB, rX] dereference must not fault regardless of what it loads -- 0x73f2c's GOT-relative read is the stack-protector guard, unrelated to argv/envp/environ, and was silently going unconstrained.

Aletheia: arm-2.27 is now 5/5 PASS (was 2 PASS + 3 FAIL). No level-0 ranking change on any arm fixture (2.23/2.27/2.39/2.43).