### PR TITLE
Move ARM/AArch64's tracked-write and cbz/cbnz logic into ArmFamily

### DIFF
--- a/lib/one_gadget/emulators/aarch64.rb
+++ b/lib/one_gadget/emulators/aarch64.rb
@@ -69,8 +69,8 @@ module OneGadget
         ops = operands(cmd)
         case mnem
         when 'b', 'b.al' then true # unconditional: control handled by the stitched path
-        when 'cbz' then branch_on_zero(ops[1].to_i(16), operand_str(ops[0]), negate: false)
-        when 'cbnz' then branch_on_zero(ops[1].to_i(16), operand_str(ops[0]), negate: true)
+        when 'cbz' then handle_cbz(ops, negate: false)
+        when 'cbnz' then handle_cbz(ops, negate: true)
         when 'tbz' then branch_on_bit(ops[2].to_i(16), operand_str(ops[0]), Integer(ops[1]), negate: false)
         when 'tbnz' then branch_on_bit(ops[2].to_i(16), operand_str(ops[0]), Integer(ops[1]), negate: true)
         else branch_on_compare(COND[mnem[2..]], ops[0].to_i(16))
@@ -120,19 +120,7 @@ module OneGadget
         raise_unsupported('stp', reg1, reg2, dst) unless reg64?(reg1) && reg64?(reg2)
 
         dst_l = arg_to_lambda(dst).ref!
-        stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
-        if stack
-          cur_top = dst_l.immi
-          stack[cur_top] = registers[reg1]
-          stack[cur_top + size_t] = registers[reg2]
-        end
-        # sp/bp are always writable (the gadget's own stack/frame): no constraint
-        # needed. Any OTHER register (a tracked write history, or none at all)
-        # might not be, so still record the requirement even when the write IS
-        # also tracked for later precise resolution -- the fetcher drops this if
-        # that resolution ends up superseding it (see base.rb's resolvable_stack
-        # callers), same as it already does for the frame pointer's own case.
-        add_writable(dst_l) unless [sp_based_stack, bp_based_stack].include?(stack)
+        track_write(dst_l, registers[reg1], registers[reg2])
 
         registers[sp] += arg_to_lambda(dst).immi if dst.end_with?('!')
       end
@@ -142,15 +130,7 @@ module OneGadget
         raise_unsupported('str', src, dst, index) unless OneGadget::Helper.integer?(index)
 
         dst_l = arg_to_lambda(dst).ref!
-        # A tracked register: sp/bp, or any other register a write has been
-        # staged through this candidate (see Processor#reg_based_stack).
-        stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
-        stack[dst_l.immi] = registers[src] if stack
-        # sp/bp are always writable: no constraint needed. Any OTHER register
-        # might not be, so still record the requirement even when the write IS
-        # also tracked for later precise resolution -- the fetcher drops this if
-        # that resolution ends up superseding it.
-        add_writable(dst_l) unless [sp_based_stack, bp_based_stack].include?(stack)
+        track_write(dst_l, registers[src])
 
         index = Integer(index)
         return unless dst.end_with?('!') || index.nonzero?

--- a/lib/one_gadget/emulators/arm.rb
+++ b/lib/one_gadget/emulators/arm.rb
@@ -177,15 +177,7 @@ module OneGadget
         raise_unsupported('str', src, dst, index) unless OneGadget::Helper.integer?(index)
 
         dst_l = arg_to_lambda(resolve_int_regs(dst)).ref!
-        # A tracked register: sp/bp, or any other register a write has been
-        # staged through this candidate (see Processor#reg_based_stack).
-        stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
-        stack[dst_l.immi] = registers[src] if stack
-        # sp/bp are always writable: no constraint needed. Any OTHER register
-        # might not be, so still record the requirement even when the write IS
-        # also tracked for later precise resolution -- the fetcher drops this if
-        # that resolution ends up superseding it.
-        add_writable(dst_l) unless [sp_based_stack, bp_based_stack].include?(stack)
+        track_write(dst_l, registers[src])
 
         index = Integer(index)
         return unless dst.end_with?('!') || index.nonzero?
@@ -239,8 +231,8 @@ module OneGadget
         ops = operands(rest)
         case mnem
         when 'b' then true # unconditional: control handled by the stitched path
-        when 'cbz' then branch_on_zero(ops[1].to_i(16), operand_str(ops[0]), negate: false)
-        when 'cbnz' then branch_on_zero(ops[1].to_i(16), operand_str(ops[0]), negate: true)
+        when 'cbz' then handle_cbz(ops, negate: false)
+        when 'cbnz' then handle_cbz(ops, negate: true)
         else branch_on_compare(COND[mnem[1..]], ops[0].to_i(16))
         end
       end

--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -107,6 +107,33 @@ module OneGadget
         dispatch_safe_call(addr, SAFE_CALLS)
       end
 
+      # A store's destination, tracked into whichever stack {#get_corresponding_stack}
+      # resolves it to (sp/bp, or a register write history -- see
+      # {Processor#reg_based_stack}), one word per entry of +values+ starting at
+      # +dst_l+. Also records the "must be writable" requirement unless the
+      # destination is sp/bp (always writable, no constraint needed) -- recorded
+      # even when the write IS also tracked, so the fetcher has it to fall back on
+      # if that resolution ends up superseded (see base.rb's resolvable_stack
+      # callers). Shared by +str+ (one value) and aarch64's +stp+ (two).
+      # @param [OneGadget::Emulators::Lambda] dst_l The destination, zero-deref
+      #   (already +ref!+'d).
+      # @param [Array<OneGadget::Emulators::Lambda, Integer>] values One value per
+      #   word, starting at +dst_l+.
+      # @return [void]
+      def track_write(dst_l, *values)
+        stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
+        values.each_with_index { |v, i| stack[dst_l.immi + size_t * i] = v } if stack
+        add_writable(dst_l) unless [sp_based_stack, bp_based_stack].include?(stack)
+      end
+
+      # +cbz+/+cbnz+ (compare-and-branch-on-zero): identical decoding in ARM and
+      # AArch64. +ops+ is +[register, target-address-hex]+, as {#operands} splits it.
+      # @param [Array<String>] ops The branch's operands.
+      # @param [Boolean] negate +false+ for +cbz+, +true+ for +cbnz+.
+      def handle_cbz(ops, negate:)
+        branch_on_zero(ops[1].to_i(16), operand_str(ops[0]), negate:)
+      end
+
       # Libc-relative addresses are known-mapped too; they carry the +$base+ marker
       # rather than a +pc+-relative one.
       def mapped_pointer?(obj)


### PR DESCRIPTION
inst_str's core body (resolve the destination's tracked stack via get_corresponding_stack, write through it if found, record a writable constraint unless it's sp/bp) was copy-pasted near-verbatim between arm.rb and aarch64.rb, plus a third copy in aarch64's inst_stp for a register pair. This is exactly the shape that let arm.rb's inst_str silently drift out of sync with aarch64's Finding-6 generalization until the recent fix -- one copy could change while the other didn't, with no error to catch it. Pulled into ArmFamily#track_write(dst_l, *values), one value per word from dst_l; str calls it with one value, stp with two.

Also folded the identical cbz/cbnz decoding (branch_on_zero with the mnemonic's negate sense) into ArmFamily#handle_cbz, called from both files' handle_branch.

Pure refactor, no behavior change: verified byte-for-byte identical gadget lists and per-gadget constraints (level 0 and level 1) across all 4 aarch64 fixtures and all 4 arm fixtures, before vs after. Full spec suite green, rubocop clean, no new uncovered lines.

Reviewed the rest of the two files' remaining differences and confirmed they're genuine architectural differences, not accidental drift: inst_ldr's literal-pool read (arm only, aarch64 uses adrp instead), mov's pc-as-operand handling (arm only), tbz/tbnz (aarch64 only, no arm32 equivalent), add's 2-operand shorthand (arm only, aarch64's add syntax is always 3-operand + extend mode). Two further findings logged separately (not part of this refactor, no measured impact on the current fixture set): aarch64 has no resolve_int_regs equivalent for [xA, xB] addressing, and no `sub` instruction at all.