### PR TITLE
amd64/i386: require readable pointer for posix_spawnattr setsig* args

### DIFF
--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -204,11 +204,15 @@ module OneGadget
       #   isn't already known to be mapped, +<arg> == NULL+ is recorded so the
       #   callee takes the skip-the-dereference path. Only tag an argument this way
       #   after confirming the callee both NULL-checks it and still reaches the
-      #   terminal call on the NULL path; an argument dereferenced unconditionally
-      #   cannot be made safe by forcing it NULL (gate it with +:global_var?+, or
-      #   drop the candidate, instead). The check is deferred to
-      #   {#finalize_deferred_reads} because a +<reg>+<imm>+ pointer may only become
-      #   known-mapped once a later store marks +<reg>+ writable.
+      #   terminal call on the NULL path.
+      # * +:deref+ - the callee dereferences this argument *unconditionally* (no
+      #   NULL guard), so it can't be made safe by forcing it NULL. When the pointer
+      #   isn't already known to be mapped, +<arg> is a valid pointer+ is recorded so
+      #   the attacker knows it must reference readable memory.
+      #   @example +posix_spawnattr_setsigmask(attr, set)+ runs +attr->__ss = *set+
+      # Both deref checks are deferred to {#finalize_deferred_reads} because a
+      # +<reg>+<imm>+ pointer may only become known-mapped once a later store marks
+      # +<reg>+ writable.
       # @return [nil, :fail] +nil+ = call accepted, +:fail+ = abort the candidate.
       def dispatch_safe_call(addr, checker)
         func = checker.keys.find { |n| addr.include?(n) }
@@ -216,7 +220,9 @@ module OneGadget
 
         checker[func].each do |idx, req|
           if req == :nullable_deref
-            @deferred_reads << argument(idx)
+            @deferred_reads << [argument(idx), :nullable]
+          elsif req == :deref
+            @deferred_reads << [argument(idx), :readable]
           elsif !check_argument(idx, req)
             return :fail
           end
@@ -224,14 +230,23 @@ module OneGadget
         nil
       end
 
-      # Now that emulation is complete and the full writable set is known, require
-      # each deferred pointer argument to be NULL unless it is already known to
-      # reference mapped memory. Idempotent: the queue is cleared once resolved.
+      # Now that emulation is complete and the full writable set is known, record
+      # the residual constraint for each deferred pointer argument, unless it is
+      # already known to reference mapped memory. A +:nullable+ deref becomes
+      # +<arg> == NULL+ (take the skip-the-dereference path); a +:readable+ deref
+      # becomes +<arg> is a valid pointer+ (NULL can't satisfy an unconditional
+      # dereference). Idempotent: the queue is cleared once resolved.
       def finalize_deferred_reads
-        @deferred_reads.each do |arg|
-          next if deref_safe_pointer?(arg) || writable_pointer?(arg)
+        @deferred_reads.each do |arg, kind|
+          if kind == :readable
+            next if mapped_nonnull_pointer?(arg) || writable_pointer?(arg)
 
-          @constraints << [:raw, "#{arg} == NULL"]
+            @constraints << [:raw, "#{arg} is a valid pointer"]
+          else
+            next if deref_safe_pointer?(arg) || writable_pointer?(arg)
+
+            @constraints << [:raw, "#{arg} == NULL"]
+          end
         end
         @deferred_reads = []
       end
@@ -240,6 +255,15 @@ module OneGadget
       # to reference mapped memory (see {#mapped_pointer?}).
       def deref_safe_pointer?(val)
         return true if val.is_a?(Integer) && val.zero?
+        return false unless val.is_a?(OneGadget::Emulators::Lambda) && val.deref_count.zero?
+
+        mapped_pointer?(val.obj.to_s)
+      end
+
+      # Whether +val+ is already known to be a non-NULL pointer into mapped memory
+      # -- the safety bar for an *unconditional* dereference, which (unlike
+      # {#deref_safe_pointer?}) NULL cannot clear.
+      def mapped_nonnull_pointer?(val)
         return false unless val.is_a?(OneGadget::Emulators::Lambda) && val.deref_count.zero?
 
         mapped_pointer?(val.obj.to_s)

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -18,12 +18,18 @@ module OneGadget
       # +sigprocmask+ dereferences its +set+ argument (arg 1) unless it is NULL (which
       # it NULL-checks), so +set+ is marked +:nullable_deref+; +__sigaction+'s
       # dereferenced +act+ (arg 1) is required to be a libc global instead.
-      # See {Processor#dispatch_safe_call}.
+      # Two +posix_spawnattr_+ setters copy *from* their second argument
+      # unconditionally (no NULL guard), so it must be a readable pointer
+      # (+:deref+); they are listed before the generic +posix_spawnattr_+ prefix so
+      # the specific requirement wins. See {Processor#dispatch_safe_call}.
+      # @example +posix_spawnattr_setsigmask(attr, set)+ runs +attr->__ss = *set+
       SAFE_CALLS = {
         'sigprocmask' => { 1 => :nullable_deref },
         '__close' => {},
         'unsetenv' => { 0 => :global_var? },
         '__sigaction' => { 1 => :global_var?, 2 => :zero? },
+        'posix_spawnattr_setsigmask' => { 1 => :deref },
+        'posix_spawnattr_setsigdefault' => { 1 => :deref },
         'posix_spawnattr_' => {},
         'posix_spawn_file_actions_' => {}
       }.freeze

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -94,6 +94,7 @@ module OneGadget
       # Expr: (s32)[<Identity>] <= 0
       # Expr: .+ is a valid argv
       # Expr: .+ is a valid envp
+      # Expr: <REG> is a valid pointer
       # Expr: <Expr> || <Expr>
       def calculate_score(expr)
         return expr.split(' || ').map(&method(:calculate_score)).max if expr.include?(' || ')
@@ -107,7 +108,7 @@ module OneGadget
         # is an easy "must be zero" like a NULL pointer, not a generic branch relation.
         when /\A\([su]\d+\).+ == 0x0$/ then calculate_null_score(expr.sub(' == 0x0', ''))
         when / <= 0x0$/ then calculate_null_score(expr.sub(' <= 0x0', ''))
-        when / is a valid (argv|envp)$/ then 0.2 # This usually means the register has to be a readable pointer.
+        when / is a valid (argv|envp|pointer)$/ then 0.2 # This usually means the register has to be a readable pointer.
         when / (==|!=|<=|>=|<|>) / then calculate_relation_score(expr) # a branch condition
         end
       end

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -64,6 +64,16 @@ describe 'one_gadget_amd64' do
       expect(gadget.constraints).to include('{"sh", "-c", rbx, NULL} is a valid argv')
     end
 
+    # 0x51df8 enters before the posix_spawnattr_setsigmask/setsigdefault calls,
+    # which copy *from* their second argument unconditionally, so r12/r13 must be
+    # readable pointers (poisoning them faults the parent before execve).
+    it 'libc-2.31 requires the setsigmask/setsigdefault pointers be readable' do
+      path = data_path('libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so')
+      gadget = OneGadget.gadgets(file: path, force_file: true, level: 1, details: true)
+                        .find { |g| g.offset == 0x51df8 }
+      expect(gadget.constraints).to include('r12 is a valid pointer', 'r13 is a valid pointer')
+    end
+
     it 'libc-2.43' do
       path = data_path('libc-2.43-90ebd03ae9d9f42b23b4eb82fdf70352cf744198.so')
       expect(OneGadget.gadgets(file: path, force_file: true,


### PR DESCRIPTION
posix_spawnattr_setsigmask/setsigdefault copy *from* their second argument unconditionally (no NULL guard), so a gadget entering before those calls needs that pointer to reference readable memory. The emulator accepted all posix_spawnattr_* helpers with no argument constraints, missing this -- e.g. libc-2.31 0x51df8 needs r12/r13 readable, which was unconstrained (poisoning them faults the parent before execve; confirmed empirically via Aletheia).

Adds a :deref safe-call requirement (unconditional dereference) that records "<arg> is a valid pointer" when the pointer isn't already known-mapped, alongside the existing NULL-guarded :nullable_deref. The new constraint scores like a valid argv/envp (a readable-pointer requirement).