### PR TITLE
emulators: share resolve_int_regs, apply it on aarch64 loads/stores

### DIFF
--- a/lib/one_gadget/emulators/aarch64.rb
+++ b/lib/one_gadget/emulators/aarch64.rb
@@ -96,8 +96,8 @@ module OneGadget
       def inst_ldr(dst, src, index = 0)
         check_register!(dst)
 
-        src_l = arg_to_lambda(src)
-        registers[dst] = src_l
+        src = resolve_int_regs(src)
+        registers[dst] = arg_to_lambda(src)
         raise_unsupported('ldr', dst, src, index) unless OneGadget::Helper.integer?(index)
 
         index = Integer(index)
@@ -119,6 +119,7 @@ module OneGadget
       def inst_stp(reg1, reg2, dst)
         raise_unsupported('stp', reg1, reg2, dst) unless reg64?(reg1) && reg64?(reg2)
 
+        dst = resolve_int_regs(dst)
         dst_l = arg_to_lambda(dst).ref!
         track_write(dst_l, registers[reg1], registers[reg2])
 
@@ -129,6 +130,7 @@ module OneGadget
         check_register!(src)
         raise_unsupported('str', src, dst, index) unless OneGadget::Helper.integer?(index)
 
+        dst = resolve_int_regs(dst)
         dst_l = arg_to_lambda(dst).ref!
         track_write(dst_l, registers[src])
 

--- a/lib/one_gadget/emulators/arm.rb
+++ b/lib/one_gadget/emulators/arm.rb
@@ -277,19 +277,6 @@ module OneGadget
         list.tr('{}', '').split(',').map(&:strip)
       end
 
-      # Replace register tokens that currently hold a concrete integer with that
-      # integer, so memory operands like +[r8, r2]+ (r2 == 0xd8) become +[r8, 0xd8]+.
-      # @example
-      #   # with r2 currently holding 0xd8
-      #   resolve_int_regs('[r8, r2]')
-      #   #=> '[r8, 0xd8]'
-      def resolve_int_regs(str)
-        str.gsub(/[a-z]+\d*/) do |tok|
-          v = registers[tok] if register?(tok)
-          v.is_a?(Integer) ? OneGadget::Helper.hex(v) : tok
-        end
-      end
-
       class << self
         # ARM (32-bit) is 32-bit.
         def bits

--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -134,6 +134,20 @@ module OneGadget
         branch_on_zero(ops[1].to_i(16), operand_str(ops[0]), negate:)
       end
 
+      # Replace register tokens that currently hold a concrete integer with that
+      # integer, so a register-indexed memory operand becomes an offset one the
+      # Lambda parser handles.
+      # @example
+      #   # with the index register currently holding 0xd8
+      #   resolve_int_regs('[r8, r2]')  #=> '[r8, 0xd8]'
+      #   resolve_int_regs('[x8, x2]')  #=> '[x8, 0xd8]'
+      def resolve_int_regs(str)
+        str.gsub(/[a-z]+\d*/) do |tok|
+          v = registers[tok] if register?(tok)
+          v.is_a?(Integer) ? OneGadget::Helper.hex(v) : tok
+        end
+      end
+
       # Libc-relative addresses are known-mapped too; they carry the +$base+ marker
       # rather than a +pc+-relative one.
       def mapped_pointer?(obj)


### PR DESCRIPTION
resolve_int_regs (replace a register token holding a concrete integer with that literal, so [base, index] becomes a parseable [base, imm]) lived only in Arm. Move it to ArmFamily and apply it in AArch64s inst_ldr/inst_str/inst_stp, matching Arm and removing the duplicate.

A register-indexed operand whose index is a resolved integer is now modelled instead of aborting the candidate. No gadget changes on the current aarch64 fixtures (their register-indexed operands all have a symbolic index or a scaled/extended one, neither of which this handles), so this is parity/robustness for future targets, verified byte-identical.