### PR TITLE
aarch64: support the sub instruction

### DIFF
--- a/lib/one_gadget/emulators/aarch64.rb
+++ b/lib/one_gadget/emulators/aarch64.rb
@@ -43,7 +43,8 @@ module OneGadget
           Instruction.new('ldr', 2..3),
           Instruction.new('mov', 2),
           Instruction.new('stp', 3),
-          Instruction.new('str', 2..3)
+          Instruction.new('str', 2..3),
+          Instruction.new('sub', 3..4)
         ]
       end
 
@@ -78,13 +79,24 @@ module OneGadget
       end
 
       def inst_add(dst, src, op2, mode = 'sxtw')
+        arith('add', dst, src, op2, mode) { |a, b| a + b }
+      end
+
+      def inst_sub(dst, src, op2, mode = 'sxtw')
+        arith('sub', dst, src, op2, mode) { |a, b| a - b }
+      end
+
+      # Shared add/sub. Only the plain (default +sxtw+) form with an immediate
+      # +op2+ is modelled; a shifted/extended register operand aborts. The block
+      # combines the resolved source and immediate.
+      def arith(name, dst, src, op2, mode)
         check_register!(dst)
 
         src = arg_to_lambda(src)
         op2 = arg_to_lambda(op2)
-        raise_unsupported('add', dst, src, op2) unless op2.is_a?(Integer) && mode == 'sxtw'
+        raise_unsupported(name, dst, src, op2) unless op2.is_a?(Integer) && mode == 'sxtw'
 
-        registers[dst] = src + op2
+        registers[dst] = yield(src, op2)
       end
 
       def inst_adrp(dst, imm)

--- a/spec/one_gadget_aarch64_spec.rb
+++ b/spec/one_gadget_aarch64_spec.rb
@@ -61,14 +61,15 @@ describe 'one_gadget_aarch64' do
     it 'libc-2.43' do
       path = data_path('aarch64-libc-2.43.so')
       expect(OneGadget.gadgets(file: path, force_file: true))
-        .to eq [0x4bc00, 0x4bc04, 0x4bc08, 0x4bc0c, 0x4bc10, 0x4bc14, 0x4bc18, 0x4bc1c]
+        .to eq [0x4bc00, 0x4bc04, 0x4bc08, 0x4bc0c, 0x4bc10, 0x4bc14, 0x4bc18, 0x4bc1c, 0xc7b00]
     end
 
     it 'resolves posix_spawn (do_system) gadgets' do
       path = data_path('aarch64-libc-2.43.so')
       gadgets = OneGadget.gadgets(file: path, force_file: true, details: true)
       expect(gadgets.map(&:effect).uniq)
-        .to eq ['posix_spawn(sp+0xc, "/bin/sh", 0, sp+0x218, sp+0x50, environ)']
+        .to eq ['posix_spawn(sp+0xc, "/bin/sh", 0, sp+0x218, sp+0x50, environ)',
+                'execve("/bin/sh", x29-0x20, x6)']
     end
 
     # do_system passes {"sh", "-c", "--", <command>, NULL}; the "-c" and "--"
@@ -82,15 +83,25 @@ describe 'one_gadget_aarch64' do
       expect(gadget.constraints.join).not_to include('$base') # no unresolved global
     end
 
-    # The execve("/bin/sh") gadget in 2.43's execvp is split across a
-    # `cmp x2, #1; b.ne`, so it only appears once the not-taken branch is
-    # expressed as the constraint `x2 == 0x1`.
+    # 2.23's execvpe reaches this execve only on the taken edge of a
+    # `cmp w21, #1; b.eq`, so the gadget carries that branch as `w21 == 0x1`.
     it 'resolves a gadget guarded by a conditional branch' do
-      path = data_path('aarch64-libc-2.43.so')
+      path = data_path('aarch64-libc-2.23.so')
       gadget = OneGadget.gadgets(file: path, force_file: true, level: 1, details: true)
-                        .find { |g| g.offset == 0xc7a3c }
-      expect(gadget.effect).to eq 'execve("/bin/sh", sp+0x10, x6)'
-      expect(gadget.constraints).to include('x2 == 0x1')
+                        .find { |g| g.offset == 0x9b9e0 }
+      expect(gadget.effect).to eq 'execve("/bin/sh", sp, x20)'
+      expect(gadget.constraints).to include('w21 == 0x1')
+    end
+
+    # 0xc7b00 stages argv at `sub x4, x29, #0x20`; without sub support the whole
+    # candidate aborts. It dominates the cmp-guarded 0xc7a3c (same execve, but no
+    # `x2 == 0x1`), so it is the one that surfaces (here as a top-level gadget).
+    it 'resolves an execve gadget reachable only through a sub' do
+      path = data_path('aarch64-libc-2.43.so')
+      gadget = OneGadget.gadgets(file: path, force_file: true, details: true)
+                        .find { |g| g.offset == 0xc7b00 }
+      expect(gadget.effect).to eq 'execve("/bin/sh", x29-0x20, x6)'
+      expect(gadget.constraints).not_to include('x2 == 0x1')
     end
   end
 


### PR DESCRIPTION
aarch64 modelled add but not sub, so any candidate whose window included a sub (common: bp/sp-relative address setup) was aborted wholesale. Add inst_sub, sharing an arith helper with inst_add (only the plain immediate form is modelled, matching add).

This recovers a real gadget: libc-2.43 0xc7b00 stages argv at `sub x4, x29, #0x20` and reaches execve("/bin/sh", x29-0x20, x6) without the `x2 == 0x1` that its cmp-guarded sibling 0xc7a3c needs -- so it dominates 0xc7a3c and surfaces as a top-level gadget (empirically PASSes under Aletheia). Updated the affected 2.43 specs; repointed the conditional-branch example to 2.23 0x9b9e0 (0xc7a3c is now trimmed).