### PR TITLE
emulators: render the readable constraint as "readable: <reg>"

### DIFF
--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -165,16 +165,16 @@ module OneGadget
       def render_constraint(type, obj)
         case type
         when :writable then "writable: #{obj}"
-        when :readable then "#{obj} is a valid pointer"
+        when :readable then "readable: #{obj}"
         else obj
         end
       end
 
       # Drop a "<reg> != 0x0" branch constraint that another constraint already
       # implies: an address constraint (+writable: <reg>+imm+ store target, or
-      # +<reg> is a valid pointer+) forces <reg> to be a valid (mapped, non-NULL)
-      # pointer, so a NULL-check branch on the same register adds nothing. Keeps
-      # the emitted set minimal.
+      # +readable: <reg>+) forces <reg> to be a valid (mapped, non-NULL) pointer,
+      # so a NULL-check branch on the same register adds nothing. Keeps the
+      # emitted set minimal.
       # @param [Array<[Symbol, Object]>] cons The de-duplicated constraint list.
       # @return [Array<[Symbol, Object]>]
       def drop_implied_nonzero(cons)
@@ -256,8 +256,8 @@ module OneGadget
       #   terminal call on the NULL path.
       # * +:deref+ - the callee dereferences this argument *unconditionally* (no
       #   NULL guard), so it can't be made safe by forcing it NULL. When the pointer
-      #   isn't already known to be mapped, +<arg> is a valid pointer+ is recorded so
-      #   the attacker knows it must reference readable memory.
+      #   isn't already known to be mapped, +readable: <arg>+ is recorded so the
+      #   attacker knows it must reference readable memory.
       #   @example +posix_spawnattr_setsigmask(attr, set)+ runs +attr->__ss = *set+
       # Both deref checks are deferred to {#finalize_deferred_reads} because a
       # +<reg>+<imm>+ pointer may only become known-mapped once a later store marks

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -89,12 +89,12 @@ module OneGadget
       # Identity: [<Identity>]
       # Expr: <REG> is the GOT address of libc
       # Expr: writable: <Identity>
+      # Expr: readable: <Identity>
       # Expr: <CAST>?<Identity> == NULL
       # Expr: <REG> & 0xf == <IMM>
       # Expr: (s32)[<Identity>] <= 0
       # Expr: .+ is a valid argv
       # Expr: .+ is a valid envp
-      # Expr: <REG> is a valid pointer
       # Expr: <Expr> || <Expr>
       def calculate_score(expr)
         return expr.split(' || ').map(&method(:calculate_score)).max if expr.include?(' || ')
@@ -108,7 +108,9 @@ module OneGadget
         # is an easy "must be zero" like a NULL pointer, not a generic branch relation.
         when /\A\([su]\d+\).+ == 0x0$/ then calculate_null_score(expr.sub(' == 0x0', ''))
         when / <= 0x0$/ then calculate_null_score(expr.sub(' <= 0x0', ''))
-        when / is a valid (argv|envp|pointer)$/ then 0.2 # This usually means the register has to be a readable pointer.
+        # A register that just has to be a readable pointer -- a "readable: <reg>"
+        # (a dereferenced call arg) or a valid argv/envp element -- is easy.
+        when /^readable/, / is a valid (argv|envp)$/ then 0.2
         when / (==|!=|<=|>=|<|>) / then calculate_relation_score(expr) # a branch condition
         end
       end

--- a/spec/emulators/amd64_spec.rb
+++ b/spec/emulators/amd64_spec.rb
@@ -38,8 +38,8 @@ describe OneGadget::Emulators::Amd64 do
 
   describe 'implied constraints' do
     # posix_spawnattr_setsigmask copies *rsi unconditionally, so its pointer must
-    # be readable ("r12 is a valid pointer"); the following test/jne (taken) also
-    # yields "r12 != 0x0", which the readable constraint makes redundant.
+    # be readable ("readable: r12"); the following test/jne (taken) also yields
+    # "r12 != 0x0", which the readable constraint makes redundant.
     it 'drops "reg != 0" a readable-pointer constraint already implies' do
       @processor.process('1000: mov rsi,r12')
       @processor.process('1004: call 10d0b0 <posix_spawnattr_setsigmask@@GLIBC_2.2.5>')
@@ -47,7 +47,7 @@ describe OneGadget::Emulators::Amd64 do
       @processor.process('100b: jne 2000 <x>')
       @processor.process('2000: nop') # branch taken -> r12 != 0
       cons = @processor.constraints
-      expect(cons).to include('r12 is a valid pointer')
+      expect(cons).to include('readable: r12')
       expect(cons).not_to include('r12 != 0x0')
     end
   end

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -81,7 +81,7 @@ describe 'one_gadget_amd64' do
       path = data_path('libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so')
       gadget = OneGadget.gadgets(file: path, force_file: true, level: 1, details: true)
                         .find { |g| g.offset == 0x51df8 }
-      expect(gadget.constraints).to include('r12 is a valid pointer', 'r13 is a valid pointer')
+      expect(gadget.constraints).to include('readable: r12', 'readable: r13')
     end
 
     it 'libc-2.43' do


### PR DESCRIPTION
The :readable address constraint printed as "<reg> is a valid pointer", inconsistent with its sibling :writable ("writable: <reg>"). Render it "readable: <reg>" to match. Only libc-2.31 0x51df8 carries readable constraints; its output changes accordingly, everything else identical. Score it like the valid-argv/envp readable-pointer case (0.2).