### PR TITLE
aarch64/arm: require the frame pointer be writable for its stores

### DIFF
--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -107,23 +107,19 @@ module OneGadget
         dispatch_safe_call(addr, SAFE_CALLS)
       end
 
-      # A store's destination, tracked into whichever stack {#get_corresponding_stack}
-      # resolves it to (sp/bp, or a register write history -- see
-      # {Processor#reg_based_stack}), one word per entry of +values+ starting at
-      # +dst_l+. Also records the "must be writable" requirement unless the
-      # destination is sp/bp (always writable, no constraint needed) -- recorded
-      # even when the write IS also tracked, so the fetcher has it to fall back on
-      # if that resolution ends up superseded (see base.rb's resolvable_stack
-      # callers). Shared by +str+ (one value) and aarch64's +stp+ (two).
-      # @param [OneGadget::Emulators::Lambda] dst_l The destination, zero-deref
-      #   (already +ref!+'d).
-      # @param [Array<OneGadget::Emulators::Lambda, Integer>] values One value per
-      #   word, starting at +dst_l+.
+      # Track a store: write +values+ (one per word from +dst_l+) into the stack
+      # {#get_corresponding_stack} resolves +dst_l+ to, and require +dst_l+
+      # writable -- unless it is a pure +sp+ store. +sp+ is invariantly the
+      # writable stack; the frame pointer only conventionally is, so a store
+      # through it stays a real precondition (like amd64's +writable: rbp+imm+).
+      # Shared by +str+ (one value) and +stp+ (two).
+      # @param [OneGadget::Emulators::Lambda] dst_l The destination, zero-deref.
+      # @param [Array<OneGadget::Emulators::Lambda, Integer>] values One per word.
       # @return [void]
       def track_write(dst_l, *values)
         stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
         values.each_with_index { |v, i| stack[dst_l.immi + size_t * i] = v } if stack
-        add_writable(dst_l) unless [sp_based_stack, bp_based_stack].include?(stack)
+        add_writable(dst_l) unless stack.equal?(sp_based_stack)
       end
 
       # +cbz+/+cbnz+ (compare-and-branch-on-zero): identical decoding in ARM and

--- a/spec/one_gadget_aarch64_spec.rb
+++ b/spec/one_gadget_aarch64_spec.rb
@@ -22,17 +22,19 @@ describe 'one_gadget_aarch64' do
 
     it 'libc-2.27' do
       path = data_path('aarch64-libc-2.27.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f160, 0x63e90, 0xa32e8, 0xa32ec]
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f160, 0x63e90, 0xa32e8]
     end
 
-    it 'constrains argv[1] for an argv built off the frame pointer' do
+    it 'constrains argv[1] and the frame for an argv built off the frame pointer' do
       path = data_path('aarch64-libc-2.27.so')
       gadget = OneGadget.gadgets(file: path, force_file: true, details: true, level: 1)
-                        .find { |g| g.offset == 0xa3234 }
-      # execve("/bin/sh", x29+0x40, ...): the code stores x0 as argv[1] in the
-      # frame, so x0 must be NULL (or a valid arg) -- not an opaque "valid argv".
-      expect(gadget.effect).to eq 'execve("/bin/sh", x29+0x40, x2)'
+                        .find { |g| g.offset == 0xa32e8 }
+      # execve("/bin/sh", x29+0x40, ...): the code stores x0 as argv[1] into the
+      # frame, so x0 must be NULL (or a valid arg) -- not an opaque "valid argv" --
+      # and the frame pointer x29 must point at writable memory.
+      expect(gadget.effect).to eq 'execve("/bin/sh", x29+0x40, x23)'
       expect(gadget.constraints).to include('x0 == NULL || {"/bin/sh", x0, NULL} is a valid argv')
+      expect(gadget.constraints).to include('writable: x29+0x40')
     end
 
     # do_system reaches execve via a sigprocmask(set) call that dereferences its
@@ -61,15 +63,14 @@ describe 'one_gadget_aarch64' do
     it 'libc-2.43' do
       path = data_path('aarch64-libc-2.43.so')
       expect(OneGadget.gadgets(file: path, force_file: true))
-        .to eq [0x4bc00, 0x4bc04, 0x4bc08, 0x4bc0c, 0x4bc10, 0x4bc14, 0x4bc18, 0x4bc1c, 0xc7b00]
+        .to eq [0x4bc00, 0x4bc04, 0x4bc08, 0x4bc0c, 0x4bc10, 0x4bc14, 0x4bc18, 0x4bc1c]
     end
 
     it 'resolves posix_spawn (do_system) gadgets' do
       path = data_path('aarch64-libc-2.43.so')
       gadgets = OneGadget.gadgets(file: path, force_file: true, details: true)
       expect(gadgets.map(&:effect).uniq)
-        .to eq ['posix_spawn(sp+0xc, "/bin/sh", 0, sp+0x218, sp+0x50, environ)',
-                'execve("/bin/sh", x29-0x20, x6)']
+        .to eq ['posix_spawn(sp+0xc, "/bin/sh", 0, sp+0x218, sp+0x50, environ)']
     end
 
     # do_system passes {"sh", "-c", "--", <command>, NULL}; the "-c" and "--"
@@ -94,13 +95,14 @@ describe 'one_gadget_aarch64' do
     end
 
     # 0xc7b00 stages argv at `sub x4, x29, #0x20`; without sub support the whole
-    # candidate aborts. It dominates the cmp-guarded 0xc7a3c (same execve, but no
-    # `x2 == 0x1`), so it is the one that surfaces (here as a top-level gadget).
+    # candidate aborts. It builds argv in the frame, so it needs `writable:
+    # x29-0x20` (and, unlike its cmp-guarded sibling 0xc7a3c, no `x2 == 0x1`).
     it 'resolves an execve gadget reachable only through a sub' do
       path = data_path('aarch64-libc-2.43.so')
-      gadget = OneGadget.gadgets(file: path, force_file: true, details: true)
+      gadget = OneGadget.gadgets(file: path, force_file: true, level: 1, details: true)
                         .find { |g| g.offset == 0xc7b00 }
       expect(gadget.effect).to eq 'execve("/bin/sh", x29-0x20, x6)'
+      expect(gadget.constraints).to include('writable: x29-0x20')
       expect(gadget.constraints).not_to include('x2 == 0x1')
     end
   end


### PR DESCRIPTION
ArmFamily#track_write skipped add_writable for both sp- and bp-based stores. sp is invariantly the writable stack, but the frame pointer only *conventionally* points there -- a store through it is a real precondition (amd64 already emits "writable: rbp+imm" for the analogous store). Skip only sp_based_stack, so a store through x29 (or arm fp) now records "writable: x29+imm".

Surfaced by the strict Aletheia sweep: gadgets building argv in the frame (aarch64-2.27 0xa32e8/0xa32ec, 2.43 0xc7b00) FAILd because x29 was poisoned; the constraint was missing. Blast radius (aarch64+arm, all levels): those gadgets gain writable: x29+imm; the frame-pointer argv entry 0xa3234 is now dominated by its sp-relative sibling 0xa321c (sp needs no writable), and 0xc7b00 no longer dominates the cmp-guarded 0xc7a3c. Specs updated accordingly.