### PR TITLE
amd64/i386: drop writable constraint for pure stack-pointer stores

### DIFF
--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -326,13 +326,15 @@ module OneGadget
       end
 
       # Whether a store through +lmda+ imposes a "must be writable" constraint. A
-      # fixed libc-internal target does not: pc-relative here, plus amd64's
-      # concretized +$base+ globals.
-      # @example (pc is +rip+)
-      #   needs_writable?(arg_to_lambda('rax'))  #=> true   # an attacker register
-      #   needs_writable?(arg_to_lambda('rip'))  #=> false  # pc-relative libc address
+      # store lands on writable memory for free when the target is the stack
+      # pointer (the stack is always writable) or a fixed libc-internal address;
+      # a frame pointer or attacker register still needs the constraint.
+      # @example (sp is +rsp+, pc is +rip+)
+      #   needs_writable?(arg_to_lambda('rax'))       #=> true   # an attacker register
+      #   needs_writable?(arg_to_lambda('[rsp+0x8]')) #=> false  # the stack is writable
+      #   needs_writable?(arg_to_lambda('rip'))       #=> false  # pc-relative libc address
       def needs_writable?(lmda)
-        lmda.obj != pc
+        lmda.obj != pc && lmda.obj != sp
       end
 
       def to_lambda(reg)

--- a/spec/emulators/amd64_spec.rb
+++ b/spec/emulators/amd64_spec.rb
@@ -58,6 +58,16 @@ describe OneGadget::Emulators::Amd64 do
       expect(cons).to include('readable: r12')
       expect(cons).not_to include('r12 != 0x0')
     end
+
+    # The stack is always writable, so a pure stack-pointer store needs no
+    # "writable" constraint; a store through any other register still does.
+    it 'omits "writable" for a stack-pointer store but keeps it otherwise' do
+      @processor.process('1000: mov QWORD PTR [rsp+0x30],rax')
+      @processor.process('1004: mov QWORD PTR [rbx+0x8],rax')
+      cons = @processor.constraints
+      expect(cons).not_to include('writable: rsp+0x30')
+      expect(cons).to include('writable: rbx+0x8')
+    end
   end
 
   describe 'process' do

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -12,7 +12,7 @@ describe 'one_gadget_amd64' do
     it 'libc-2.19' do
       path = data_path('libc-2.19-cf699a15caae64f50311fc4655b86dc39a479789.so')
       expect(OneGadget.gadgets(file: path, force_file: true, level: 1))
-        .to eq [0x461fb, 0x46421, 0x46428, 0x4647c, 0xc18d1, 0xc18d8, 0xc1ba3, 0xc1bf2, 0xc1ca7,
+        .to eq [0x46421, 0x46428, 0x4647c, 0xc18d1, 0xc18d8, 0xc1ba3, 0xc1bf2, 0xc1ca7,
                 0xe4968, 0xe5765, 0xe5771, 0xe654d, 0xe6552, 0xe6557, 0xe6670, 0xe6677, 0xe6685, 0xe668a,
                 0xe668f, 0xe6697, 0xe669e, 0xe66bd]
     end
@@ -37,7 +37,7 @@ describe 'one_gadget_amd64' do
 
     it 'libc-2.24' do
       path = data_path('libc-2.24-8cba3297f538691eb1875be62986993c004f3f4d.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f3aa, 0xb8a38, 0xd67e5]
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x3f356, 0x3f3aa, 0xb8a38, 0xd67e5]
       expect(one_gadget(path)).to eq OneGadget.gadgets(file: path)
     end
 
@@ -58,8 +58,8 @@ describe 'one_gadget_amd64' do
       path = data_path('libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so')
       expect(OneGadget.gadgets(file: path, force_file: true,
                                level: 1)).to eq [0x51df8, 0x51e2b, 0x51e32, 0x51e39, 0x51e40, 0x51e45, 0x51e55, 0x51e5a,
-                                                 0x51e5d, 0x51e62, 0x84165, 0x8416c, 0x84173, 0x84176, 0x8417b, 0x84180,
-                                                 0x8418c, 0x84192, 0x84199, 0x841a0, 0xe3b2e, 0xe3b31, 0xe3b34, 0xe3d23,
+                                                 0x51e62, 0x84165, 0x8416c, 0x84173, 0x84176, 0x8417b, 0x84180,
+                                                 0x8418c, 0x84192, 0x84199, 0xe3b2e, 0xe3b31, 0xe3b34, 0xe3d23,
                                                  0xe3d26, 0xe3d88, 0xe3d92, 0xe3d99, 0xe3da0, 0xe3dd7, 0xe3de1,
                                                  0x1075e7, 0x1075f1, 0x107cea]
       expect(OneGadget.gadgets(file: path)).to eq [0xe3b2e, 0xe3b31, 0xe3b34]


### PR DESCRIPTION
The stack is always writable, so a `writable: rsp/esp+imm` constraint on a store through the stack pointer is noise. needs_writable? now excludes sp as well as pc/$base.

Removing the fake constraint also lets trim_gadgets fold strictly-harder siblings that differed only in this token, and lets a couple of gadgets that were penalized solely by it score honestly into level 0.