### PR TITLE
Drop execve gadgets whose argv disables shell execution

### DIFF
--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -171,7 +171,11 @@ module OneGadget
       # @param [String] argv_ptr The pointer to the argv array. See above.
       # @param [Boolean] allow_null
       #   Whether +argv_ptr+ itself may be +NULL+ (true for +execve+, false for +posix_spawn+).
-      # @return [String, nil] The constraint string, or +nil+ when no constraint is needed.
+      # @return [String, nil, false] How {#resolve_execve_args} should treat this argv:
+      #   a +String+ is a constraint it must add; +nil+ means the argv is already
+      #   valid so no constraint is needed; +false+ means the argv can never launch
+      #   a shell (e.g. a fixed noexec option), which it consumes as an
+      #   unsatisfiable constraint and drops the gadget.
       def check_argv(processor, argv_ptr, allow_null)
         argv_ptr = resolve_stack_deref(processor, argv_ptr)
         lmda = OneGadget::Emulators::Lambda.parse(argv_ptr)
@@ -208,6 +212,9 @@ module OneGadget
       # Handle the case where +argv_ptr+ points into the stack, so the +argv+ entries can be read off it.
       # @param [String] argv_ptr The pointer to the argv array. See {#check_argv}.
       # @param [OneGadget::Emulators::Lambda] lmda The parsed +argv_ptr+ (a stack register, zero dereference).
+      # @return [String, nil, false] The same three-way contract as {#check_argv},
+      #   which returns this value unchanged: a constraint, +nil+ (already valid),
+      #   or +false+ (drop the gadget).
       def check_stack_argv(processor, argv_ptr, lmda, allow_null)
         stack = processor.get_corresponding_stack(lmda.obj)
         # A stack register we don't track a stack for (the frame pointer):
@@ -215,6 +222,10 @@ module OneGadget
         return check_nonstack_argv(lmda.to_s, allow_null) if stack.nil?
 
         argv = (0..3).map { |i| stack[lmda.immi + processor.class.bits / 8 * i].to_s }
+
+        # A shell spawned with a fixed "noexec" option never runs a command, so
+        # drop the gadget (see this method's @return for the +false+ contract).
+        return false if noexec_shell_argv?(argv)
 
         # if argv is already valid, no constraints are needed! (but probably won't happen :p)
         return if argv_already_valid?(argv)
@@ -273,6 +284,21 @@ module OneGadget
         else
           "#{argv[0]} == NULL || #{argv_cons}"
         end
+      end
+
+      # Whether +argv+ invokes the shell with a fixed option word that disables
+      # command execution. execve's program is always "/bin/sh", so +argv[1]+ is
+      # that shell's option word; a libc-global bundle carrying the noexec flag
+      # there yields a shell that reaches execve yet can never run a command --
+      # a false positive to drop.
+      # @param [Array<String>] argv The resolved argv entries. See {#check_stack_argv}.
+      # @return [Boolean]
+      # @example decided by argv[1]'s libc-global content (via global_str_content)
+      #   # content "-nc" carries bash's noexec 'n' => true;
+      #   # "-c" runs the command => false; a non-global (attacker) word => false
+      def noexec_shell_argv?(argv)
+        opt = global_str_content(argv[1])
+        !opt.nil? && opt.match?(/\A-[a-zA-Z]*n[a-zA-Z]*\z/)
       end
 
       # Handle the case where +argv_ptr+ is not a plain stack pointer (e.g. a register or global variable).

--- a/spec/fetchers/base_spec.rb
+++ b/spec/fetchers/base_spec.rb
@@ -24,6 +24,20 @@ describe OneGadget::Fetchers::Base do
     end
   end
 
+  describe '#noexec_shell_argv?' do
+    # execve's program is always "/bin/sh", so argv[1] is that shell's option
+    # word. A fixed "-n" (noexec) bundle parses input but runs nothing; "-c"
+    # runs the command; a non-global (attacker-set) word imposes no such flag.
+    it 'flags a noexec option word but not -c or a non-global word' do
+      allow(fetcher).to receive(:global_str_content).and_return('-nc')
+      expect(fetcher.send(:noexec_shell_argv?, ['"sh"', 'g', 'x', '0'])).to be true
+      allow(fetcher).to receive(:global_str_content).and_return('-c')
+      expect(fetcher.send(:noexec_shell_argv?, ['"sh"', 'g', 'x', '0'])).to be false
+      allow(fetcher).to receive(:global_str_content).and_return(nil)
+      expect(fetcher.send(:noexec_shell_argv?, ['"sh"', 'rbx', 'x', '0'])).to be false
+    end
+  end
+
   describe '#check_envp' do
     # envp is a bare stack register (deref_count == 0), the "just in case"
     # branch that reads the envp array off the stack.

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -13,8 +13,7 @@ describe 'one_gadget_amd64' do
       path = data_path('libc-2.19-cf699a15caae64f50311fc4655b86dc39a479789.so')
       expect(OneGadget.gadgets(file: path, force_file: true, level: 1))
         .to eq [0x46421, 0x46428, 0x4647c, 0xc18d1, 0xc18d8, 0xc1ba3, 0xc1bf2, 0xc1ca7,
-                0xe4968, 0xe5765, 0xe5771, 0xe654d, 0xe6552, 0xe6557, 0xe6670, 0xe6677, 0xe6685, 0xe668a,
-                0xe668f, 0xe6697, 0xe669e, 0xe66bd]
+                0xe4968, 0xe5765, 0xe5771, 0xe654d, 0xe6552, 0xe6557, 0xe669e, 0xe66bd]
     end
 
     # 0xc1ca7 builds argv in place at rax (mov [rsi],rax with rsi==rax), so rax


### PR DESCRIPTION
A gadget whose argv gives /bin/sh a fixed "-n" (noexec) option -- e.g. {"sh", "-nc", cmd, NULL} -- reaches execve but the shell only parses its input and runs nothing, so it is a false positive. execve's program is always "/bin/sh", so argv[1] is that shell's option word; when it resolves to a libc-global bundle carrying the noexec flag, drop the gadget.

Removes 6 such gadgets on amd64 libc-2.19 (0xe6670/77/85/8a/8f/97).