### PR TITLE
Add level 2: emit all gadgets including trimmed ones

### DIFF
--- a/lib/one_gadget/fetchers.rb
+++ b/lib/one_gadget/fetchers.rb
@@ -11,6 +11,10 @@ require 'one_gadget/helper'
 module OneGadget
   # To find gadgets.
   module Fetchers
+    # At and above this level, keep every distinct gadget instead of trimming
+    # down to the easiest-to-reach set (see {ClassMethods#from_file}).
+    RAW_LEVEL = 2
+
     # Define class methods here.
     module ClassMethods
       # Fetch one-gadget offsets of this build id.
@@ -26,9 +30,14 @@ module OneGadget
 
       # Fetch one-gadget offsets from file.
       # @param [String] file The absolute path of libc file.
+      # @param [Integer] level
+      #   Output level. Below {RAW_LEVEL} the result is trimmed to the
+      #   easiest-to-reach gadgets ({#trim_gadgets}); at {RAW_LEVEL} and above
+      #   every distinct gadget is kept ({#all_gadgets}), including ones a lower
+      #   level drops as duplicate or harder-to-satisfy.
       # @return [Array<OneGadget::Gadget::Gadget>]
       #   Array of all found gadgets is returned.
-      def from_file(file)
+      def from_file(file, level: 0)
         arch = OneGadget::Helper.architecture(file)
         klass = {
           aarch64: OneGadget::Fetchers::AArch64,
@@ -38,10 +47,20 @@ module OneGadget
         }[arch]
         raise Error::UnsupportedArchitectureError, arch if klass.nil?
 
-        trim_gadgets(klass.new(file).find)
+        gadgets = klass.new(file).find
+        level >= RAW_LEVEL ? all_gadgets(gadgets) : trim_gadgets(gadgets)
       end
 
       private
+
+      # Keep every distinct gadget, dropping only exact +(offset, constraints)+
+      # repeats (the same suffix reached by more than one candidate path). Unlike
+      # {#trim_gadgets} this keeps duplicate-constraint and dominated gadgets, and
+      # lists an offset once per constraint set it can be reached under.
+      def all_gadgets(gadgets)
+        gadgets.uniq { |g| [g.offset, g.constraints] }
+               .sort_by { |g| [g.offset, g.constraints.size] }
+      end
 
       # Unique, remove gadgets with harder constraints.
       def trim_gadgets(gadgets)

--- a/lib/one_gadget/one_gadget.rb
+++ b/lib/one_gadget/one_gadget.rb
@@ -22,8 +22,11 @@ module OneGadget
     #   When +file+ is given, {OneGadget} will search gadgets according its
     #   build id first. +force_file = true+ to disable this feature.
     # @param [Integer] level
-    #   Output level.
-    #   If +level+ equals to zero, only gadgets with highest successful probability would be output.
+    #   Output level. Higher levels show more of the gadgets found.
+    #   +0+ (default) shows only the gadgets with the highest successful
+    #   probability; +1+ shows the full trimmed set; +2+ and above additionally
+    #   include gadgets a lower level drops as duplicate or harder-to-satisfy
+    #   (this emulates the file, bypassing the build-id database).
     # @return [Array<OneGadget::Gadget::Gadget>, Array<Integer>]
     #   The gadgets found.
     # @example
@@ -33,10 +36,16 @@ module OneGadget
       ret = if build_id
               OneGadget::Fetchers.from_build_id(build_id) || OneGadget::Logger.not_found(build_id)
             else
-              from_file(OneGadget::Helper.abspath(file), force: force_file)
+              # level >= RAW_LEVEL wants every gadget, but the build-id database
+              # only stores the trimmed set, so emulate the file instead of it.
+              force = force_file || level >= OneGadget::Fetchers::RAW_LEVEL
+              from_file(OneGadget::Helper.abspath(file), force:, level:)
             end
       ret = refine_gadgets(ret, level)
-      ret = ret.map(&:offset) unless details
+      # An offset can recur at level >= 2 (one entry point, several branch-reach
+      # constraint sets); the offset-only view lists it once. A no-op at lower
+      # levels, where offsets are already unique.
+      ret = ret.map(&:offset).uniq unless details
       ret
     rescue OneGadget::Error::Error => e
       OneGadget::Logger.error("#{e.class.name.split('::').last}: #{e.message}")
@@ -46,10 +55,10 @@ module OneGadget
     private
 
     # Try from build id first, then file
-    def from_file(path, force: false)
+    def from_file(path, force: false, level: 0)
       OneGadget::Helper.verify_elf_file!(path)
       gadgets = try_from_build(path) unless force
-      gadgets || OneGadget::Fetchers.from_file(path)
+      gadgets || OneGadget::Fetchers.from_file(path, level:)
     end
 
     def try_from_build(file)

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -91,6 +91,28 @@ describe 'one_gadget_amd64' do
       expect(OneGadget.gadgets(file: path)).to eq [0xf87a3, 0x11d7aa, 0x11d7b2, 0x11d7b7]
     end
 
+    # Level 2 keeps every distinct gadget, restoring ones level 1 trims as
+    # duplicate or harder-to-reach, while still omitting ones dropped as invalid.
+    it 'libc-2.19 level 2 restores trimmed gadgets but not invalid ones' do
+      path = data_path('libc-2.19-cf699a15caae64f50311fc4655b86dc39a479789.so')
+      l1 = OneGadget.gadgets(file: path, force_file: true, level: 1)
+      l2 = OneGadget.gadgets(file: path, force_file: true, level: 2)
+      expect(l2.size).to be > l1.size
+      expect(l1).not_to include(0x461fb) # dominated by 0x46421 -> trimmed at level 1
+      expect(l2).to include(0x461fb)     # ... but kept at level 2
+      expect(l2).not_to include(0xe6670) # a "-nc" noexec argv: invalid, never emitted
+    end
+
+    # One entry point can be reached under several branch-dependent constraint
+    # sets; level 2 keeps each in detail but lists the offset once.
+    it 'libc-2.31 level 2 dedupes offsets yet keeps per-branch variants in detail' do
+      path = data_path('libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so')
+      offsets = OneGadget.gadgets(file: path, force_file: true, level: 2)
+      details = OneGadget.gadgets(file: path, force_file: true, level: 2, details: true)
+      expect(offsets).to eq(offsets.uniq)
+      expect(details.size).to be > offsets.size
+    end
+
     it 'not ELF' do
       expect { hook_logger { OneGadget.gadgets(file: __FILE__) } }.to output(<<-EOS).to_stdout
 [OneGadget] ArgumentError: Not an ELF file, expected glibc as input


### PR DESCRIPTION
Level 2 (and above) keeps every distinct gadget found instead of trimming to the easiest-to-reach set, restoring ones level 1 drops as duplicate or dominated by a lower-constraint sibling. It emulates the file -- the build-id database only stores the trimmed set -- and lists each offset once in the offset-only view while keeping per-branch constraint variants in detail.