### PR TITLE
emulators: unify add_writable/needs_writable?/libc_base in Processor

### DIFF
--- a/lib/one_gadget/emulators/amd64.rb
+++ b/lib/one_gadget/emulators/amd64.rb
@@ -56,13 +56,6 @@ module OneGadget
            .sub(/\s*#.*/, '') # to end-of-line, not \z: the objdump line may end in "\n"
       end
 
-      # The libc load base as a symbolic lambda (cf. {ArmFamily#libc_base}).
-      # @example
-      #   libc_base.to_s  #=> '$base'
-      def libc_base
-        @libc_base ||= OneGadget::Emulators::Lambda.new('$base')
-      end
-
       # Build a lambda for a concretized +$base+<off>+ operand (optionally
       # bracketed); anything else falls back to {Processor#arg_to_lambda}.
       # @example
@@ -84,13 +77,6 @@ module OneGadget
       #   global_var?('rax')          #=> false
       def global_var?(obj)
         super || obj.to_s.include?(libc_base.obj)
-      end
-
-      # A concretized libc global is a fixed target, so it needs no writable constraint.
-      # @example
-      #   needs_writable?(arg_to_lambda('$base+0x100'))  #=> false
-      def needs_writable?(lmda)
-        super && lmda.obj != libc_base.obj
       end
     end
   end

--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -76,29 +76,6 @@ module OneGadget
           v.is_a?(Integer) ? OneGadget::Helper.hex(v) : tok
         end
       end
-
-      # Libc-relative addresses are known-mapped too; they carry the +$base+ marker
-      # rather than a +pc+-relative one.
-      def mapped_pointer?(obj)
-        super || obj == libc_base.obj.to_s
-      end
-
-      # The libc load base as a symbolic +$base+ lambda.
-      def libc_base
-        @libc_base ||= OneGadget::Emulators::Lambda.new('$base')
-      end
-
-      # +$base+-relative addresses are treated as read-only; any other store
-      # target must be writable, so record it as a constraint.
-      def add_writable(lmda)
-        # XXX: a tighter check would consult the libc's writable LOAD segments.
-        return if lmda.obj == libc_base.obj
-        # The stack is invariantly writable, so a pure sp-relative target needs no
-        # constraint (cf. x86's needs_writable?, and the sp-skip in #track_write).
-        return if lmda.obj == sp
-
-        @constraints << [:writable, lmda]
-      end
     end
   end
 end

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -375,10 +375,39 @@ module OneGadget
         !!stack && !stack.empty?
       end
 
-      # Whether an address expression names memory known to be mapped: a stack slot
-      # or a libc global. Architectures with an extra base marker override this.
+      # Whether an address expression names memory known to be mapped: a stack slot,
+      # the libc base, or a libc global.
       def mapped_pointer?(obj)
-        obj.include?(sp) || global_var?(obj)
+        obj.include?(sp) || obj == libc_base.obj.to_s || global_var?(obj)
+      end
+
+      # The libc load base as a symbolic +$base+ lambda. Only the arches that
+      # concretize libc-relative operands (amd64's +rip+, arm's +pc+) ever produce
+      # it; elsewhere it never matches a real operand, so it's harmless.
+      # @example
+      #   libc_base.to_s #=> '$base'
+      def libc_base
+        @libc_base ||= OneGadget::Emulators::Lambda.new('$base')
+      end
+
+      # Record a "must be writable" constraint for a store's target address.
+      # @param [OneGadget::Emulators::Lambda] lmda The destination address, zero-deref
+      #   (already +ref!+'d by the caller).
+      def add_writable(lmda)
+        @constraints << [:writable, lmda] if needs_writable?(lmda)
+      end
+
+      # Whether a store through +lmda+ imposes a "must be writable" constraint. It
+      # lands on writable-or-fixed memory for free when the target is the stack
+      # pointer (the stack is always writable), the program counter, or the libc
+      # base (a fixed libc-internal address); a frame pointer or attacker register
+      # still needs the constraint.
+      # @example (sp is +rsp+, pc is +rip+)
+      #   needs_writable?(arg_to_lambda('rax'))        #=> true   # an attacker register
+      #   needs_writable?(arg_to_lambda('[rsp+0x8]'))  #=> false  # the stack is writable
+      #   needs_writable?(arg_to_lambda('$base+0x10')) #=> false  # a fixed libc global
+      def needs_writable?(lmda)
+        ![sp, pc, libc_base.obj.to_s].include?(lmda.obj.to_s)
       end
 
       def register?(reg)

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -254,25 +254,6 @@ module OneGadget
         dispatch_safe_call(addr)
       end
 
-      # Record a "must be writable" constraint for a store's target address.
-      # @param [OneGadget::Emulators::Lambda] lmda The destination address,
-      #   zero-deref (already +ref!+'d by the caller).
-      def add_writable(lmda)
-        @constraints << [:writable, lmda] if needs_writable?(lmda)
-      end
-
-      # Whether a store through +lmda+ imposes a "must be writable" constraint. A
-      # store lands on writable memory for free when the target is the stack
-      # pointer (the stack is always writable) or a fixed libc-internal address;
-      # a frame pointer or attacker register still needs the constraint.
-      # @example (sp is +rsp+, pc is +rip+)
-      #   needs_writable?(arg_to_lambda('rax'))       #=> true   # an attacker register
-      #   needs_writable?(arg_to_lambda('[rsp+0x8]')) #=> false  # the stack is writable
-      #   needs_writable?(arg_to_lambda('rip'))       #=> false  # pc-relative libc address
-      def needs_writable?(lmda)
-        lmda.obj != pc && lmda.obj != sp
-      end
-
       def to_lambda(reg)
         return super unless reg =~ /^xmm\d+$/
 


### PR DESCRIPTION
The writable-skip logic had drifted: X86 skipped pc/sp via needs_writable? (amd64 overriding to also skip $base), while arm_family skipped $base/sp inline in its own add_writable -- so the #28 sp-skip had to be written twice. And libc_base was defined verbatim in both amd64 and arm_family.

Move add_writable, one needs_writable? (skips sp, pc, and the libc base), and libc_base to Processor, and fold arm_family's mapped_pointer? override into the base (it now checks the libc base directly). x86/amd64/arm_family drop their copies. i386 inherits a libc_base it never produces, which is harmless.

Behaviour-preserving: gadget output byte-identical across every fixture at levels 0/1/2 on all four arches.