### PR TITLE
Fix cmn-based compares: shifted immediates and unsigned conditions

### DIFF
--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -32,6 +32,36 @@ module OneGadget
 
       private
 
+      # A compare whose second operand may carry a shift modifier, e.g.
+      # +cmn x0, 0x1, lsl 12+ (the immediate is 0x1000, not 0x1). Fold a constant
+      # shift into the operand; abort on any modifier not modelled, since dropping
+      # it would silently understate the constraint.
+      # @return [Boolean] false aborts the candidate.
+      def handle_compare(op, cmd)
+        ops = operands(cmd)
+        return false if ops.size > 3
+
+        rhs = operand_str(ops[1])
+        if ops.size == 3
+          rhs = shifted_operand(rhs, ops[2])
+          return false if rhs.nil?
+        end
+        record_compare(op, operand_str(ops[0]), rhs)
+      end
+
+      # Apply a constant shift modifier to an already-rendered operand.
+      # @return [String, nil] nil when the shift isn't a constant amount applied to
+      #   a known integer, which the caller treats as unmodelled.
+      # @example
+      #   shifted_operand('0x1', 'lsl 12') #=> '0x1000'
+      def shifted_operand(rhs, modifier)
+        m = modifier.match(/\A(lsl|lsr|asr)\s+(\d+)\z/)
+        return nil unless m && OneGadget::Helper.integer?(rhs)
+
+        value = Integer(rhs)
+        OneGadget::Helper.hex(m[1] == 'lsl' ? value << Integer(m[2]) : value >> Integer(m[2]))
+      end
+
       # A +bl+/+blx+ call: record the terminal +exec*+ target, accept a known-safe
       # syscall wrapper, or +:fail+ to abort the candidate.
       def inst_bl(addr)

--- a/lib/one_gadget/emulators/conditional.rb
+++ b/lib/one_gadget/emulators/conditional.rb
@@ -234,23 +234,45 @@ module OneGadget
         operator, sign = rel
         operator = NEGATE[operator] unless taken
         cast = sign ? "(#{sign}#{self.class.bits})" : ''
-        __send__(COMPARE_OPS.fetch(op)[:render], cast, lhs, rhs, operator)
+        __send__(COMPARE_OPS.fetch(op)[:render], cast, lhs, rhs, operator, sign)
       end
 
       # Subtraction (+:sub+): a direct comparison of the two operands.
-      def render_sub(cast, lhs, rhs, op)
+      def render_sub(cast, lhs, rhs, op, _sign)
         rhs = ZERO if rhs == '0'
         "#{cast}#{lhs} #{op} #{rhs}"
       end
 
-      # Addition (+:add+): the flags reflect +lhs + rhs+, i.e. that sum compared against 0.
-      def render_add(cast, lhs, rhs, op)
-        "#{cast}(#{lhs} + #{rhs}) #{op} #{ZERO}"
+      # Addition (+:add+): the flags reflect +lhs + rhs+ compared against 0 -- but
+      # only for a signed or equality condition. An *unsigned* condition reads the
+      # carry out of the addition instead, which holds over a whole range of +lhs+,
+      # not just the one value making the sum zero: the carry is set exactly when
+      # +lhs + rhs+ wraps, i.e. when +lhs >= -rhs+. So the condition is +lhs+
+      # against +-rhs+, the form the subtractive compares already produce.
+      # @example glibc's "the syscall didn't return -errno" check, +cmn x0, 0x1000+
+      #   followed by a not-taken +b.hi+, is +(u64)x0 <= 0xfffffffffffff000+ --
+      #   satisfied by x0 == 0, which "(x0 + 0x1000) <= 0" would wrongly exclude.
+      def render_add(cast, lhs, rhs, op, sign)
+        return "#{cast}(#{lhs} + #{rhs}) #{op} #{ZERO}" unless sign == :u && negatable?(rhs)
+
+        "#{cast}#{lhs} #{op} #{OneGadget::Helper.hex((-Integer(rhs)) & mask)}"
       end
 
       # Bitwise AND (+:and+): a bitmask test; identical operands collapse to a plain zero test.
-      def render_and(_cast, lhs, rhs, op)
+      def render_and(_cast, lhs, rhs, op, _sign)
         lhs == rhs ? "#{lhs} #{op} #{ZERO}" : "(#{lhs} & #{rhs}) #{op} #{ZERO}"
+      end
+
+      # Whether +rhs+ can be moved to the other side of an unsigned add-compare.
+      # A zero addend never carries, so the condition doesn't reduce to a bound and
+      # the sum form is kept.
+      def negatable?(rhs)
+        OneGadget::Helper.integer?(rhs) && !Integer(rhs).zero?
+      end
+
+      # All-ones for this architecture's word size.
+      def mask
+        (1 << self.class.bits) - 1
       end
 
       # The address of an objdump line, used to tell whether the pending branch

--- a/spec/emulators/aarch64_spec.rb
+++ b/spec/emulators/aarch64_spec.rb
@@ -36,6 +36,25 @@ describe OneGadget::Emulators::AArch64 do
       expect(branch_constraint('cmp x0, #0x400', 'b.lt', 0x2000, 0x1008)).to eq ['(s64)x0 >= 0x400'] # not taken
     end
 
+    it 'renders cmn as a bound, folding a shifted immediate' do
+      # glibc's "the syscall didn't return -errno" check. An unsigned condition
+      # after cmn reads the carry, so it bounds x0 rather than forcing x0+0x1000
+      # to be zero -- x0 == 0 satisfies it. Same form amd64 emits for this check.
+      expect(branch_constraint('cmn x0, #0x1, lsl #12', 'b.hi', 0x2000, 0x1008))
+        .to eq ['(u64)x0 <= 0xfffffffffffff000'] # not taken
+      @processor = described_class.new
+      expect(branch_constraint('cmn x0, #0x1, lsl #12', 'b.hi', 0x2000, 0x2000))
+        .to eq ['(u64)x0 > 0xfffffffffffff000'] # taken
+      # An equality condition does read the sum, so it keeps the additive form.
+      @processor = described_class.new
+      expect(branch_constraint('cmn x0, #0x1', 'b.eq', 0x2000, 0x2000)).to eq ['(x0 + 0x1) == 0x0']
+    end
+
+    it 'aborts on a compare modifier it cannot model' do
+      # Silently dropping the modifier would understate the constraint.
+      expect(@processor.process('1000: cmn x0, x1, lsl x2')).to be false
+    end
+
     it 'renders cbz / cbnz' do
       expect(branch_constraint(nil, 'cbz x0,', 0x2000, 0x1008)).to eq ['x0 != 0x0'] # not taken
       @processor = described_class.new


### PR DESCRIPTION
Two problems made `cmn`-guarded gadgets carry constraints no attacker could meet, so they looked unusable:

* `cmn x0, #0x1, lsl #12` compares against 0x1000, but the shift operand was dropped, leaving 0x1. Fold a constant shift into the operand, and abort the candidate on any modifier not modelled rather than silently dropping it.

* An unsigned condition after an add-based compare reads the carry out of the addition, not the sum's value: the carry is set exactly when lhs + rhs wraps, so the condition bounds lhs by -rhs instead of forcing the sum to zero. It now renders `(u64)x0 <= 0xfffffffffffff000` -- the same form amd64 already emits for this glibc "syscall didn't return -errno" check -- where before it said `(u64)(x0 + 0x1) <= 0x0`, pinning x0 to one value that contradicted the gadget's own `w0 == 0x0`. Signed and equality conditions do read the sum and keep the additive form.

Three aarch64 gadgets (2.23 0x3d3d8, 2.24 0x3c630, 2.27 0x3eee4) go from unsatisfiable to verified PASS under Aletheia; shipped level 0/1 output is unchanged.