### PR TITLE
Record branch comparisons as their parts, not rendered text

### DIFF
--- a/lib/one_gadget/emulators/conditional.rb
+++ b/lib/one_gadget/emulators/conditional.rb
@@ -158,7 +158,7 @@ module OneGadget
         op = @flags[:op]
         lhs = @flags[:lhs]
         rhs = @flags[:rhs]
-        @pending = { target:, render: ->(taken) { compare_constraint(op, lhs, rhs, rel, taken) } }
+        @pending = { target:, compare: ->(taken) { compare_triple(op, lhs, rhs, rel, taken) } }
         true
       end
 
@@ -176,7 +176,7 @@ module OneGadget
       def branch_on_zero(target, reg, negate:)
         hit = negate ? '!=' : '==' # taken (not negated) => reg == 0
         miss = negate ? '==' : '!='
-        @pending = { target:, render: ->(taken) { "#{reg} #{taken ? hit : miss} #{ZERO}" } }
+        @pending = { target:, compare: ->(taken) { [reg, taken ? hit : miss, ZERO] } }
         true
       end
 
@@ -193,7 +193,7 @@ module OneGadget
         mask = OneGadget::Helper.hex(1 << bit)
         hit = negate ? '!=' : '=='
         miss = negate ? '==' : '!='
-        @pending = { target:, render: ->(taken) { "(#{reg} & #{mask}) #{taken ? hit : miss} #{ZERO}" } }
+        @pending = { target:, compare: ->(taken) { ["(#{reg} & #{mask})", taken ? hit : miss, ZERO] } }
         true
       end
 
@@ -214,7 +214,7 @@ module OneGadget
         return if @pending.nil?
 
         taken = branch_addr(cmd) == @pending[:target]
-        @constraints << [:raw, @pending[:render].call(taken)]
+        @constraints << [:cmp, @pending[:compare].call(taken)]
         @pending = nil
       end
 
@@ -230,7 +230,7 @@ module OneGadget
       #   compare_constraint(:sub, 'x2', '0x1', ['!=', nil], false) #=> 'x2 == 0x1'
       # @example +jne+ (taken) after +test eax, eax+ -- an +:and+ compare
       #   compare_constraint(:and, 'eax', 'eax', ['!=', nil], true) #=> 'eax != 0'
-      def compare_constraint(op, lhs, rhs, rel, taken)
+      def compare_triple(op, lhs, rhs, rel, taken)
         operator, sign = rel
         operator = NEGATE[operator] unless taken
         cast = sign ? "(#{sign}#{self.class.bits})" : ''
@@ -240,7 +240,7 @@ module OneGadget
       # Subtraction (+:sub+): a direct comparison of the two operands.
       def render_sub(cast, lhs, rhs, op, _sign)
         rhs = ZERO if rhs == '0'
-        "#{cast}#{lhs} #{op} #{rhs}"
+        ["#{cast}#{lhs}", op, rhs]
       end
 
       # Addition (+:add+): the flags reflect +lhs + rhs+ compared against 0 -- but
@@ -253,14 +253,14 @@ module OneGadget
       #   followed by a not-taken +b.hi+, is +(u64)x0 <= 0xfffffffffffff000+ --
       #   satisfied by x0 == 0, which "(x0 + 0x1000) <= 0" would wrongly exclude.
       def render_add(cast, lhs, rhs, op, sign)
-        return "#{cast}(#{lhs} + #{rhs}) #{op} #{ZERO}" unless sign == :u && negatable?(rhs)
+        return ["#{cast}(#{lhs} + #{rhs})", op, ZERO] unless sign == :u && negatable?(rhs)
 
-        "#{cast}#{lhs} #{op} #{OneGadget::Helper.hex((-Integer(rhs)) & mask)}"
+        ["#{cast}#{lhs}", op, OneGadget::Helper.hex((-Integer(rhs)) & mask)]
       end
 
       # Bitwise AND (+:and+): a bitmask test; identical operands collapse to a plain zero test.
       def render_and(_cast, lhs, rhs, op, _sign)
-        lhs == rhs ? "#{lhs} #{op} #{ZERO}" : "(#{lhs} & #{rhs}) #{op} #{ZERO}"
+        [lhs == rhs ? lhs : "(#{lhs} & #{rhs})", op, ZERO]
       end
 
       # Whether +rhs+ can be moved to the other side of an unsigned add-compare.

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -135,7 +135,9 @@ module OneGadget
       # dereference, see {#finalize_deferred_reads}). Both are keyed, offset-
       # normalised, and imply non-NULL identically; they differ only in how they
       # render (see {#render_constraint}). The remaining type, +:raw+, carries a
-      # ready-made constraint string that keys on itself.
+      # ready-made constraint string that keys on itself, and +:cmp+ a comparison
+      # recorded as its +[lhs, operator, rhs]+ parts (see {Conditional}), so it can
+      # be inspected rather than re-parsed from the rendered text.
       ADDRESS_TYPES = %i[writable readable].freeze
 
       # @return [Array<String>]
@@ -174,6 +176,7 @@ module OneGadget
         case type
         when :writable then "writable: #{obj}"
         when :readable then "readable: #{obj}"
+        when :cmp then obj.join(' ')
         else obj
         end
       end
@@ -192,7 +195,7 @@ module OneGadget
         return cons if nonzero_regs.empty?
 
         cons.reject do |type, obj|
-          type == :raw && (m = /\A(\S+) != 0x0\z/.match(obj)) && nonzero_regs.include?(m[1])
+          type == :cmp && obj[1] == '!=' && obj[2] == ZERO && nonzero_regs.include?(obj[0])
         end
       end
 


### PR DESCRIPTION
A resolved branch became a finished string, so anything wanting to reason about it -- whether two constraints can hold at once, say -- would have to re-parse the text it had just formatted. Keep the comparison as [lhs, operator, rhs] and join it when the constraint list is rendered.

Behaviour is unchanged: level 0/1 output and every level-2 constraint string are byte-identical across all fixtures.