### PR TITLE
Read a slot back as what the gadget put in it

### DIFF
--- a/lib/one_gadget/emulators/aarch64.rb
+++ b/lib/one_gadget/emulators/aarch64.rb
@@ -107,8 +107,7 @@ module OneGadget
         check_register!(dst)
 
         src = resolve_int_regs(src)
-        val = arg_to_lambda(src)
-        note_read(val)
+        val = read_value(arg_to_lambda(src))
         registers[dst] = val
         raise_unsupported('ldr', dst, src, index) unless OneGadget::Helper.integer?(index)
 

--- a/lib/one_gadget/emulators/arm.rb
+++ b/lib/one_gadget/emulators/arm.rb
@@ -161,8 +161,7 @@ module OneGadget
         check_register!(dst)
         raise_unsupported('ldr', dst, src, index) unless OneGadget::Helper.integer?(index)
 
-        val = src.include?(pc) ? literal_value : arg_to_lambda(resolve_int_regs(src))
-        note_read(val)
+        val = src.include?(pc) ? literal_value : read_value(arg_to_lambda(resolve_int_regs(src)))
         registers[dst] = val
 
         index = Integer(index)

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -483,6 +483,39 @@ module OneGadget
         @constraints << [:writable, lmda] if needs_writable?(lmda)
       end
 
+      # The value an instruction reads through +val+: what this candidate put at
+      # that address, when it is one the candidate has written, and the
+      # dereference itself otherwise (recording the read, see {#note_read}).
+      #
+      # A slot the gadget fills in reads back as what was put there, so a
+      # constraint on it names the value the caller has to arrange rather than
+      # whatever the slot held on entry -- which the gadget has already replaced.
+      # @param [Object] val The operand's value, as produced by {#arg_to_lambda}.
+      # @return [Object]
+      # @example (arm) +str r3, [sp, #4]+ then +ldr r0, [sp, #4]+ reads back r3
+      def read_value(val)
+        stored = stored_value(val)
+        return stored unless stored.nil?
+
+        note_read(val)
+        val
+      end
+
+      # What this candidate stored at the address +val+ dereferences, or +nil+ if
+      # it stored nothing there. Only a single dereference of a base this emulator
+      # tracks names a slot it can answer for (see {#get_corresponding_stack}).
+      # @param [Object] val
+      # @return [Object, nil]
+      def stored_value(val)
+        return nil unless val.is_a?(OneGadget::Emulators::Lambda) && val.deref_count == 1
+
+        ptr = val.dup.ref!
+        return nil unless ptr.deref_count.zero?
+
+        stack = get_corresponding_stack(ptr.obj)
+        stack&.key?(ptr.immi) ? stack[ptr.immi] : nil
+      end
+
       # Require +val+'s pointer be readable when a load dereferences an
       # uncontrolled base -- one that doesn't root at mapped memory (see
       # {#mapped_pointer?}), since a value read from the stack or a libc global is

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -122,8 +122,7 @@ module OneGadget
       def inst_mov(dst, src)
         src = arg_to_lambda(src)
         if register?(dst)
-          note_read(src)
-          registers[dst] = src
+          registers[dst] = read_value(src)
           return
         end
         dst = arg_to_lambda(dst)
@@ -246,9 +245,7 @@ module OneGadget
       def inst_add(dst, src)
         check_register!(dst)
 
-        src = arg_to_lambda(src)
-        note_read(src)
-        registers[dst] += src
+        registers[dst] += read_value(arg_to_lambda(src))
       end
 
       def inst_sub(dst, src)

--- a/spec/emulators/amd64_spec.rb
+++ b/spec/emulators/amd64_spec.rb
@@ -70,6 +70,28 @@ describe OneGadget::Emulators::Amd64 do
     end
   end
 
+  describe 'reading back a slot the gadget wrote' do
+    it 'yields what was stored there, not the value the slot held on entry' do
+      @processor.process('1000: mov QWORD PTR [rsp+0x8],rdx')
+      @processor.process('1004: mov rax,QWORD PTR [rsp+0x8]')
+      expect(@processor.registers['rax'].to_s).to eq 'rdx'
+
+      # through a plain register too, not just the stack pointer
+      @processor.process('1008: mov QWORD PTR [rbx+0x8],rsi')
+      @processor.process('100c: mov rcx,QWORD PTR [rbx+0x8]')
+      expect(@processor.registers['rcx'].to_s).to eq 'rsi'
+    end
+
+    it 'still reads a slot the gadget never wrote as a dereference' do
+      @processor.process('1000: mov rax,QWORD PTR [rsp+0x8]')
+      expect(@processor.registers['rax'].to_s).to eq '[rsp+0x8]'
+      # a neighbouring slot is not the one that was written
+      @processor.process('1004: mov QWORD PTR [rsp+0x10],rdx')
+      @processor.process('1008: mov rcx,QWORD PTR [rsp+0x18]')
+      expect(@processor.registers['rcx'].to_s).to eq '[rsp+0x18]'
+    end
+  end
+
   describe 'sub-register views' do
     it 'lets a 32-bit write through to the register it names part of' do
       @processor.process('1000: mov edi,0x1')

--- a/spec/emulators/arm_spec.rb
+++ b/spec/emulators/arm_spec.rb
@@ -99,6 +99,15 @@ describe OneGadget::Emulators::Arm do
       expect(@processor.registers['r6'].to_s).to eq '[r7+0xd8]'
     end
 
+    it 'reads back a slot the gadget stored to' do
+      @processor.process('0: str r3, [sp, #4]')
+      @processor.process('4: ldr r0, [sp, #4]')
+      expect(@processor.registers['r0'].to_s).to eq 'r3'
+      # a slot it never wrote still reads as a dereference.
+      @processor.process('8: ldr r1, [sp, #8]')
+      expect(@processor.registers['r1'].to_s).to eq '[sp+0x8]'
+    end
+
     it 'str (stack, writable, $base is skipped)' do
       @processor.process('0: mov r1, sp')
       @processor.process('4: str r0, [r1], #-8')


### PR DESCRIPTION
A load took the dereference at face value even where the candidate had just stored there, so a constraint on the slot named the value it held on entry -- which the gadget has already replaced.