### PR TITLE
Let the extended registers answer to their d-names too

### DIFF
--- a/lib/one_gadget/abi.rb
+++ b/lib/one_gadget/abi.rb
@@ -23,8 +23,10 @@ module OneGadget
     # is visible through the other, which is what
     # {OneGadget::Emulators::RegisterFile} keeps them consistent about.
     # @example writing +edi+ is writing the low half of +rdi+
+    # @example writing +r8d+ is writing the low half of +r8+
     NARROW_VIEWS = {
-      amd64: %w[ax bx cx dx di si bp sp].to_h { |reg| ["e#{reg}", "r#{reg}"] },
+      amd64: (%w[ax bx cx dx di si bp sp].map { |reg| ["e#{reg}", "r#{reg}"] } +
+              8.upto(15).map { |i| ["r#{i}d", "r#{i}"] }).to_h,
       i386: {},
       aarch64: 0.upto(30).to_h { |i| ["w#{i}", "x#{i}"] }.merge('wzr' => 'xzr'),
       arm: {}

--- a/spec/emulators/amd64_spec.rb
+++ b/spec/emulators/amd64_spec.rb
@@ -129,6 +129,15 @@ describe OneGadget::Emulators::Amd64 do
       expect(@processor.registers['rax'].to_s).to eq 'rsi'
     end
 
+    it 'accepts the d-name of an extended register as that register' do
+      @processor.process('1000: mov r8d,0x1')
+      # the call's fifth argument is that 1 -- an instruction naming r8d used to
+      # be rejected outright, and r8d read as a symbol of its own.
+      expect(@processor.argument(4)).to eq 1
+      @processor.process('1004: lea r13d,[rdx+0x2]')
+      expect(@processor.registers['r13'].to_s).to eq 'rdx+0x2'
+    end
+
     it 'names the low half of an untouched register by its own name' do
       # rax is untouched, so its low half is still what "eax" names -- a narrower
       # requirement than one naming the whole register.


### PR DESCRIPTION
r8d-r15d were absent from the amd64 register list, so an instruction naming one was rejected outright, and reading one invented a symbol unrelated to the register it names half of.