### PR TITLE
Say which descriptors a gadget closes

### DIFF
--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -38,6 +38,7 @@ module OneGadget
         @sp = sp
         @constraints = []
         @deferred_reads = [] # pointer args of safe calls, resolved once emulation ends
+        @closed_fds = []     # where each descriptor closed before the terminal call comes from
         @flags = nil     # last compare, for a following conditional branch
         @pending = nil   # a conditional branch awaiting one-line-ahead resolution
         @sp_based_stack = tracked_stack(sp)
@@ -156,6 +157,12 @@ module OneGadget
       # The {POINTER_REQUIREMENTS} a NULL argument already satisfies: both ask for
       # a pointer the callee will leave alone, and NULL is how that is asked for.
       NULLABLE_REQUIREMENTS = %i[nullable_deref null].freeze
+
+      # @return [Array<String>] Where each descriptor this candidate closes is read
+      #   from, in the order they are closed, without repeats.
+      def closed_fds
+        @closed_fds.uniq
+      end
 
       # @return [Array<String>]
       #   Extra constraints found during execution.
@@ -315,6 +322,9 @@ module OneGadget
       # per-argument requirements: an argument index paired with one of
       # * +:global_var?+ - a precondition that must already hold, else the
       #   candidate is aborted (+:fail+).
+      # * +:closed_fd+ - the descriptor the callee closes. Nothing is required of
+      #   it; it is recorded, because closing a standard descriptor changes what
+      #   the spawned shell can still do (see {#note_closed_fd}).
       # * +:null+ - the callee must be given NULL here, so +<arg> == NULL+ is
       #   recorded for the caller to arrange. A value that can never be NULL --
       #   a fixed address, or any other non-zero literal -- aborts the candidate.
@@ -344,6 +354,8 @@ module OneGadget
         return :fail unless func
 
         SafeCalls::COMMON[func].each do |idx, req|
+          next note_closed_fd(argument(idx)) if req == :closed_fd
+
           ok = POINTER_REQUIREMENTS.include?(req) ? record_pointer(argument(idx), req) : check_argument(idx, req)
           return :fail unless ok
         end
@@ -406,6 +418,19 @@ module OneGadget
         return value.any? { |v| clobbered?(v) } if value.is_a?(Array)
 
         value.is_a?(OneGadget::Emulators::Lambda) && value.obj == CLOBBERED
+      end
+
+      # Record a descriptor the gadget closes on its way to the terminal call, by
+      # where it is read from.
+      #
+      # Only one the caller chooses is worth recording, since which descriptor
+      # lands there decides whether the spawned shell keeps its I/O. One fixed in
+      # the code is nobody's to change, and no path that reaches a terminal call
+      # closes one, so it isn't modelled.
+      # @param [Object] fd The descriptor argument, as {#argument} returns it.
+      # @return [void]
+      def note_closed_fd(fd)
+        @closed_fds << fd.to_s unless fd.is_a?(Integer)
       end
 
       # Record what the callee does through a pointer argument.

--- a/lib/one_gadget/emulators/safe_calls.rb
+++ b/lib/one_gadget/emulators/safe_calls.rb
@@ -23,10 +23,12 @@ module OneGadget
         # __sigaction also writes back through +oldact+ (arg 2), so oldact must be NULL.
         'sigprocmask' => { 1 => :nullable_deref },
         '__sigaction' => { 1 => :nullable_deref, 2 => :null },
-        # __close takes no pointer argument (nothing to constrain). unsetenv reads its
-        # name (arg 0); +:global_var?+ may over-constrain it (readable would suffice),
-        # but no current fixture reaches unsetenv near an exec to verify -- left as-is.
-        '__close' => {},
+        # Record the descriptor __close closes: which one it is decides whether the
+        # spawned shell keeps its I/O (see {Processor#note_closed_fd}).
+        '__close' => { 0 => :closed_fd },
+        # unsetenv reads its name (arg 0); +:global_var?+ may over-constrain it
+        # (readable would suffice), but no current fixture reaches unsetenv near an
+        # exec to verify -- left as-is.
         'unsetenv' => { 0 => :global_var? },
         # setsigmask/setsigdefault copy *set into the attr unconditionally, so the
         # source (arg 1) must be readable and the attr they write (arg 0) writable.

--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -121,6 +121,7 @@ module OneGadget
         return if options[:constraints].any? { |c| contradiction?(c) }
 
         options[:constraints] = options[:constraints].reject { |c| tautology?(c) }
+        options[:closed_fds] = processor.closed_fds
         OneGadget::Gadget::Gadget.new(offset_of(lines.first), **options)
       end
 

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -19,6 +19,9 @@ module OneGadget
       attr_reader :constraints
       # @return [String] The final result of this gadget.
       attr_reader :effect
+      # @return [Array<String>] Where each descriptor this gadget closes before the
+      #   exec is read from, in the order it closes them (see {#caveats}).
+      attr_reader :closed_fds
 
       # Initialize method of {Gadget} instance.
       # @param [Integer] offset The relative address offset of this gadget.
@@ -31,6 +34,21 @@ module OneGadget
         @offset = offset
         @constraints = options[:constraints] || []
         @effect = options[:effect] || ''
+        @closed_fds = options[:closed_fds] || []
+      end
+
+      # What the gadget costs the caller beyond its constraints: a descriptor it
+      # closes on the way to the exec. Each line names the close itself, so it
+      # reads as the code does and can be matched exactly, and says what the value
+      # must avoid for the spawned shell to keep its I/O.
+      # @return [Array<String>]
+      # @example
+      #   ['close([rsp+0x44]): prevent it from being 0 (stdin) or 1 (stdout) ...']
+      def caveats
+        closed_fds.map do |fd|
+          "close(#{fd}): prevent it from being 0 (stdin) or 1 (stdout) to sound " \
+            'an interactive shell.'
+        end
       end
 
       # Returns a human-readable, colorized representation of this gadget,
@@ -42,6 +60,11 @@ module OneGadget
           str += "#{OneGadget::Helper.colorize('constraints')}:\n  "
           str += merge_constraints.join("\n  ")
         end
+        unless caveats.empty?
+          str += "\n" unless constraints.empty?
+          str += "#{OneGadget::Helper.colorize('caveats')}:\n  "
+          str += caveats.join("\n  ")
+        end
         str.gsub!(/0x[\da-f]+/) { |s| OneGadget::Helper.colorize(s, sev: :integer) }
         OneGadget::ABI.all.each do |reg|
           str.gsub!(/([^\w])(#{reg})([^\w])/, "\\1#{OneGadget::Helper.colorize('\2', sev: :reg)}\\3")
@@ -50,15 +73,16 @@ module OneGadget
       end
 
       # Converts this gadget into a plain hash, suitable for serialization.
-      # @return [Hash{Symbol => Integer, String, Array<String>}]
+      # @return [Hash{Symbol => Integer, String, Array<String>, Array<Integer>}]
       #   A hash with keys +:value+ (the absolute address), +:effect+ (the
-      #   resulting function call) and +:constraints+ (the required constraints).
+      #   resulting function call), +:constraints+ (the required constraints) and,
+      #   when the gadget closes a descriptor, +:closed_fds+ with the {#caveats}
+      #   they carry.
       def to_obj
-        {
-          value:,
-          effect:,
-          constraints:
-        }
+        obj = { value:, effect:, constraints: }
+        return obj if caveats.empty?
+
+        obj.merge(closed_fds:, caveats:)
       end
 
       # Serializes this gadget into a JSON string.

--- a/spec/emulators/amd64_spec.rb
+++ b/spec/emulators/amd64_spec.rb
@@ -117,6 +117,21 @@ describe OneGadget::Emulators::Amd64 do
     end
   end
 
+  describe 'descriptors a gadget closes' do
+    it 'records where a closed descriptor is read from' do
+      @processor.process('1000: mov edi,DWORD PTR [rsp+0x44]')
+      @processor.process('1004: call ebe00 <__close@@GLIBC_2.2.5>')
+      expect(@processor.closed_fds).to eq ['[rsp+0x44]']
+    end
+
+    it 'says nothing about a descriptor fixed in the code' do
+      # nobody can change it, and no path reaching a terminal call closes one.
+      @processor.process('1000: mov edi,0x2')
+      @processor.process('1004: call ebe00 <__close@@GLIBC_2.2.5>')
+      expect(@processor.closed_fds).to be_empty
+    end
+  end
+
   describe 'reading back a slot the gadget wrote' do
     it 'yields what was stored there, not the value the slot held on entry' do
       @processor.process('1000: mov QWORD PTR [rsp+0x8],rdx')

--- a/spec/gadget_spec.rb
+++ b/spec/gadget_spec.rb
@@ -56,6 +56,36 @@ constraints:
     end
   end
 
+  context 'caveats' do
+    # What the gadget costs beyond its constraints. Each line names the close as
+    # the code performs it, and says what the descriptor must avoid.
+    it 'names the close and what its descriptor must not be' do
+      gadget = OneGadget::Gadget::Gadget.new(0x1234, effect: 'execve("/bin/sh", rsp+0x50, environ)',
+                                                     closed_fds: ['[rsp+0x44]'])
+      expect(gadget.caveats).to eq ['close([rsp+0x44]): prevent it from being 0 (stdin) or 1 ' \
+                                    '(stdout) to sound an interactive shell.']
+    end
+
+    it 'prints them in their own section, one line each' do
+      gadget = OneGadget::Gadget::Gadget.new(0x1234, effect: 'execve("/bin/sh", rsp+0x30, environ)',
+                                                     constraints: ['rax == NULL'],
+                                                     closed_fds: ['[rsp+0x44]', 'r12'])
+      lines = gadget.inspect.gsub(/\e\[[0-9;]*m/, '').lines.map(&:chomp)
+      expect(lines).to include 'caveats:'
+      expect(lines.grep(/\A  close\(/).size).to eq 2
+    end
+
+    it 'carries them into the serialized form, and omits the keys when there are none' do
+      plain = OneGadget::Gadget::Gadget.new(0x1234, effect: 'e', constraints: [])
+      expect(plain.to_obj.keys).to eq %i[value effect constraints]
+
+      gadget = OneGadget::Gadget::Gadget.new(0x1234, effect: 'e', constraints: [],
+                                                     closed_fds: ['[rsp+0x44]'])
+      expect(gadget.to_obj[:closed_fds]).to eq ['[rsp+0x44]']
+      expect(gadget.to_obj[:caveats].size).to eq 1
+    end
+  end
+
   context 'score' do
     def new(cons)
       OneGadget::Gadget::Gadget.new(0, constraints: cons)


### PR DESCRIPTION
A gadget that closes a descriptor on its way to the exec costs the caller something its constraints never mention. Name the close as the code performs it, and say what the descriptor must avoid so the spawned shell keeps its I/O.

Only a descriptor the caller chooses is modelled: one fixed in the code is nobody's to change, and no path that reaches a terminal call closes one.