### PR TITLE
Show the string a gadget reaches through the GOT

### DIFF
--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -497,13 +497,26 @@ module OneGadget
       # @param [String] element
       # @return [String, nil]
       def global_str_content(element)
-        m = /\A\$base\+(0x[0-9a-f]+)\z/.match(element) or return nil
+        off = string_file_offset(element) or return nil
 
         bytes = File.binread(file)
-        off = m[1].to_i(16)
+        return nil unless off.between?(0, bytes.size - 1)
+
         stop = bytes.index("\x00", off) or return nil
         str = bytes[off...stop]
         str if str.length.between?(1, 16) && str.each_byte.all? { |c| c.between?(0x20, 0x7e) }
+      end
+
+      # The file offset a fixed address names, or +nil+ when +element+ isn't one.
+      # Here that is the resolved-offset form an arch produces once it concretizes
+      # a pc-relative operand; an arch that reaches its globals through a register
+      # instead overrides this (see +I386#string_file_offset+).
+      # @param [String] element
+      # @return [Integer, nil]
+      def string_file_offset(element)
+        m = /\A\$base\+(0x[0-9a-f]+)\z/.match(element) or return nil
+
+        m[1].to_i(16)
       end
 
       def offset_of(assembly)

--- a/lib/one_gadget/fetchers/i386.rb
+++ b/lib/one_gadget/fetchers/i386.rb
@@ -59,6 +59,21 @@ module OneGadget
         str.include?(@base_reg)
       end
 
+      # i386 PIC reaches a libc global through the GOT register, so a fixed string
+      # reads as +<got reg>-<off>+ rather than the resolved +$base+<off>+ every
+      # other arch produces. What that register holds is known -- it is the PLTGOT,
+      # which is why the gadget carries a "+<reg>+ is the GOT address of libc"
+      # constraint -- so the file offset follows from it.
+      # @example +esi-0x59734+ with PLTGOT +0x1d5000+ is +0x17b8cc+, the +"-c"+ glibc
+      #   passes the shell
+      def string_file_offset(element)
+        return super if @base_reg.nil?
+
+        m = /\A#{Regexp.escape(@base_reg)}([+-]0x[0-9a-f]+)\z/.match(element) or return super
+
+        got_offset + Integer(m[1], 16)
+      end
+
       def got_offset
         File.open(file) do |f|
           elf = ELFTools::ELFFile.new(f)

--- a/spec/one_gadget_i386_spec.rb
+++ b/spec/one_gadget_i386_spec.rb
@@ -39,6 +39,20 @@ describe 'one_gadget_i386' do
       expect(OneGadget.gadgets(file: path)).to eq [0xed300, 0x18a495, 0x18a496]
     end
 
+    # A fixed libc string is reached through the GOT register on i386 PIC, so it
+    # reads as `esi-0x59734` where every other arch resolves it to `$base+<off>`
+    # and prints its content. The register's value is known -- it is the PLTGOT,
+    # which the gadget's own "is the GOT address of libc" constraint states -- so
+    # the string can be shown, and the `-c` this passes the shell is no longer
+    # indistinguishable from an argv element the caller supplies.
+    it 'shows the content of a string reached through the GOT register' do
+      path = data_path('libc-2.27-63b3d43ad45e1b0f601848c65b067f9e9b40528b.so')
+      gadget = OneGadget.gadgets(file: path, force_file: true, details: true, level: 2)
+                        .find { |g| g.offset == 0x3c98c }
+      expect(gadget.constraints).to include('esi is the GOT address of libc')
+      expect(gadget.constraints).to include('{"sh", "-c", [esp+0xc], NULL} is a valid argv')
+    end
+
     # 0xed234's own first instruction (mov [ebp-0x30], ecx) writes ecx into the
     # exact stack slot the envp check later requires to be NULL, so ecx itself is
     # the real precondition -- not the opaque "[[ebp-0x30]] == NULL" form its


### PR DESCRIPTION
i386 PIC reaches a libc global through the GOT register, so a fixed string read as <reg>-<off> where every other arch resolves it and prints its content. What that register holds is known -- the gadget's own constraint states it is the PLTGOT -- so read the string from there too.

The -c a gadget passes the shell is now visible as such, rather than looking like an argv element the caller supplies. 31 elements across the corpus; no gadget gained or lost.