### PR TITLE
Reach 100% line coverage, and keep it there

### DIFF
--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -21,6 +21,11 @@ describe OneGadget::Helper do
     expect(described_class.build_id_of(@libcpath)).to eq '60131540dadc6796cab33388349e6e4e68692053'
   end
 
+  it 'which' do
+    expect(described_class.which('ruby')).to be_a(String)
+    expect(described_class.which('one-gadget-no-such-executable')).to be_nil
+  end
+
   it 'colorize' do
     allow(described_class).to receive(:color_enabled?).and_return(true)
     expect(described_class.colorize('123', sev: :integer)).to eq "\e[38;5;189m123\e[0m"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ SimpleCov.start do
                                                      ])
   skip '/spec/'
   skip '/lib/one_gadget/builds/'
+  # The suite covers every line, so anything less is a real gap rather than a
+  # number to interpret -- and a new line arrives covered or the build says so.
+  minimum_coverage line: 100
 end
 
 # These requirements must be put after SimpleCov.start,


### PR DESCRIPTION
Helper#which had never returned its not-found answer in a test: every caller looks for something that exists. With that line covered the suite is whole, so hold it there -- a shortfall is then a real gap rather than a number to interpret against a known-missing line.