### PR TITLE
Track the argv a gadget builds through a derived pointer

### DIFF
--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -71,7 +71,7 @@ module OneGadget
       end
 
       # Track a store: write +values+ (one per word from +dst_l+) into the stack
-      # {#get_corresponding_stack} resolves +dst_l+ to, and require +dst_l+
+      # {#resolve_address} resolves +dst_l+ to, and require +dst_l+
       # writable -- unless it is a pure +sp+ store. +sp+ is invariantly the
       # writable stack; the frame pointer only conventionally is, so a store
       # through it stays a real precondition (like amd64's +writable: rbp+imm+).
@@ -80,8 +80,8 @@ module OneGadget
       # @param [Array<OneGadget::Emulators::Lambda, Integer>] values One per word.
       # @return [void]
       def track_write(dst_l, *values)
-        stack = dst_l.deref_count.zero? ? get_corresponding_stack(dst_l.obj) : nil
-        values.each_with_index { |v, i| stack[dst_l.immi + size_t * i] = v } if stack
+        stack, offset = resolve_address(dst_l)
+        values.each_with_index { |v, i| stack[offset + size_t * i] = v } if stack
         add_writable(dst_l) unless stack.equal?(sp_based_stack)
       end
 

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -237,9 +237,25 @@ module OneGadget
         end
       end
 
-      # The stack that +obj+ addresses -- +sp+-based, {#bp}-based, or a per-register
+      # Where +address+ lands in the memory this emulator tracks: the stack it
+      # falls in and its offset within it. A load or store passes the address it
+      # dereferences, i.e. its operand with that dereference peeled off.
+      # @param [Lambda, String] address An address.
+      # @return [(Hash{Integer => Lambda}?, Integer)] The stack, +nil+ if none
+      #   tracks this address, and the offset to index it at.
+      # @example an offset from a register
+      #   resolve_address(Lambda.parse('rsp+0x10')) #=> [sp_based_stack, 0x10]
+      # @example an offset from a pointer no register names
+      #   resolve_address(Lambda.parse('[rbp-0x48]+0x8')) #=> [the "[rbp-0x48]" stack, 0x8]
+      def resolve_address(address)
+        base, offset = address_base(address)
+        [get_corresponding_stack(base), offset]
+      end
+
+      # The stack that +obj+ addresses -- +sp+-based, {#bp}-based, a per-register
       # write history ({#reg_based_stack}) for any other register the candidate has
-      # written through.
+      # written through, or a per-value one ({#value_based_stack}) when no register
+      # names the base at all.
       # @param [String, Lambda] obj A lambda object or its string.
       # @return [Hash{Integer => Lambda}, nil] The corresponding stack, or nil.
       # @example
@@ -247,19 +263,40 @@ module OneGadget
       #   get_corresponding_stack('x29+0x40') #=> bp_based_stack (when bp is x29)
       #   get_corresponding_stack('x21')      #=> nil, or a write history if written through
       def get_corresponding_stack(obj)
-        # A compound base (a nested Lambda, e.g. the address is itself "[reg]+imm" --
-        # one more indirection than a simple register+offset) isn't something any of
-        # sp/bp/reg_based_stack model correctly: their imm is always "an offset from a
-        # *named register*", not "an offset from a dereferenced value". Matching it via
-        # a substring check on its rendered form (e.g. "[rbp-0x78]" contains "rbp")
-        # would silently mistrack it as bp-relative.
-        return nil if obj.is_a?(OneGadget::Emulators::Lambda)
+        # Matched before the register names below: such a base's imm is an offset
+        # from the value it names, not from any register, so a substring check on
+        # its rendered form ("[rbp-0x78]" contains "rbp") would mistrack it as
+        # bp-relative.
+        return value_based_stack(obj) if obj.is_a?(OneGadget::Emulators::Lambda)
 
         s = obj.to_s
         return sp_based_stack if s.include?(sp)
         return bp_based_stack if bp && s.include?(bp)
 
         reg_based_stack(s)
+      end
+
+      # A write history for a base that is a value rather than a register -- a
+      # pointer the candidate derived and then built an array through, which no
+      # register names. It addresses one place for as long as it names the same
+      # value, so its writes are tracked like a register's, keyed by how it
+      # renders. Only a store that overwrites what the base itself reads from
+      # would invalidate that, which a candidate short enough to be a gadget
+      # doesn't do.
+      #
+      # Without this the stores such a candidate makes are invisible, and the
+      # argv it builds in place reads as an opaque "is a valid argv" whose NULL
+      # alternatives the candidate itself overwrites.
+      # @example a pointer rounded down before use
+      #   (rsi & 0xfffffffffffffff0)
+      # @example a pointer loaded from the frame
+      #   [rbp-0x48]
+      # @param [OneGadget::Emulators::Lambda] lmda A value used as a base.
+      # @return [Hash{Integer => Lambda}]
+      def value_based_stack(lmda)
+        key = lmda.to_s
+        @value_stacks ||= {}
+        @value_stacks[key] ||= tracked_stack(key)
       end
 
       # A per-register write history for a register that ISN'T the arch's
@@ -295,6 +332,23 @@ module OneGadget
       end
 
       private
+
+      # Split +address+ into the base it is offset from and that offset, in the
+      # forms {#get_corresponding_stack} and a tracked stack expect.
+      # @param [Lambda, String] address See {#resolve_address}.
+      # @return [(String, Lambda), Integer]
+      def address_base(address)
+        return [address, 0] unless address.is_a?(OneGadget::Emulators::Lambda)
+        # Still a dereference deep, so the whole thing names one value rather than
+        # an offset from anything: its own immediate is part of that name.
+        return [address, 0] if address.deref_count.positive?
+        # An operation's +obj+ is only the value it operates on, which addresses
+        # somewhere else entirely -- a candidate building an array through
+        # +(rsi & ~0xf)+ is not writing through +rsi+.
+        return [address.dup.tap { |base| base.immi = 0 }, address.immi] if address.operation?
+
+        [address.obj, address.immi]
+      end
 
       # An always-on tracked stack keyed by offset: a Hash that lazily materialises
       # +[reg+off]+ as a one-deref {Lambda}. Used for the +sp+- and {#bp}-based stacks.
@@ -562,18 +616,15 @@ module OneGadget
       end
 
       # What this candidate stored at the address +val+ dereferences, or +nil+ if
-      # it stored nothing there. Only a single dereference of a base this emulator
-      # tracks names a slot it can answer for (see {#get_corresponding_stack}).
+      # it stored nothing there. Only a single dereference of an address this
+      # emulator tracks names a slot it can answer for (see {#resolve_address}).
       # @param [Object] val
       # @return [Object, nil]
       def stored_value(val)
-        return nil unless val.is_a?(OneGadget::Emulators::Lambda) && val.deref_count == 1
+        return nil unless val.is_a?(OneGadget::Emulators::Lambda) && val.deref_count.positive?
 
-        ptr = val.dup.ref!
-        return nil unless ptr.deref_count.zero?
-
-        stack = get_corresponding_stack(ptr.obj)
-        stack&.key?(ptr.immi) ? stack[ptr.immi] : nil
+        stack, offset = resolve_address(val.dup.ref!)
+        stack&.key?(offset) ? stack[offset] : nil
       end
 
       # Require +val+'s pointer be readable when a load dereferences an

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -130,18 +130,10 @@ module OneGadget
         dst = arg_to_lambda(dst)
         # dup: add_writable ref!s its argument, and dst is reused below.
         add_writable(dst.dup.ref!)
-        return if dst.deref_count != 1
-
-        # get_corresponding_stack takes a base (obj), not the whole pointer
-        # Lambda -- consistent with every other call site (aarch64.rb, base.rb).
-        stack = get_corresponding_stack(dst.obj)
-        return if stack.nil?
-
-        dst.ref!
-        # dst's base is a tracked register (sp/bp always resolve to 0 in
-        # eval_dict, and any other tracked register is offset-only the same
-        # way -- see Processor#reg_based_stack), so the immediate IS the offset.
-        stack[dst.immi] = src
+        # resolve_address takes the address the store writes to, i.e. the operand
+        # with the store's own dereference peeled off.
+        stack, offset = resolve_address(dst.ref!)
+        stack&.store(offset, src)
       end
 
       # +movsxd dst, src+: +src+'s low 32 bits, sign-extended into the 64-bit +dst+.

--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -203,10 +203,7 @@ module OneGadget
       #   unsatisfiable constraint and drops the gadget.
       def check_argv(processor, argv_ptr, allow_null)
         argv_ptr = resolve_stack_deref(processor, argv_ptr)
-        if argv_ptr.is_a?(OneGadget::Emulators::Lambda) && argv_ptr.deref_count.zero? &&
-           resolvable_stack(processor, argv_ptr)
-          return check_stack_argv(processor, argv_ptr, allow_null)
-        end
+        return check_stack_argv(processor, argv_ptr, allow_null) if resolvable_stack(processor, argv_ptr)
 
         check_nonstack_argv(argv_ptr, allow_null)
       end
@@ -214,7 +211,7 @@ module OneGadget
       # Whether resolving +lmda+'s target via tracked memory is worth attempting,
       # as opposed to the plain opaque "==NULL || is a valid .." form
       # ({#check_nonstack_argv}/the envp equivalent). Always true for the arch's
-      # dedicated stack/frame pointer. For any other register, only when element
+      # dedicated stack/frame pointer. For anything else, only when element
       # 0 -- what {#argv_already_valid?}/{#generate_argv_with_sh} branch on --
       # was actually written within this candidate.
       # @example element 0 tracked -- resolvable
@@ -223,29 +220,32 @@ module OneGadget
       #   reg+0x10 (element 2) tracked, reg/reg+0x8 (elements 0/1) untracked
       #   => not resolvable; falls back to the opaque form instead of a garbled array
       # @param [OneGadget::Emulators::Processor] processor
-      # @param [OneGadget::Emulators::Lambda] lmda A zero-deref pointer operand.
+      # @param [OneGadget::Emulators::Lambda, Integer] lmda A pointer operand. A
+      #   concrete address is never resolvable: nothing was tracked against it.
       # @return [Hash{Integer => OneGadget::Emulators::Lambda}, nil]
       def resolvable_stack(processor, lmda)
-        stack = processor.get_corresponding_stack(lmda.obj)
-        return nil unless stack
-        return stack if OneGadget::ABI.stack_register?(lmda.obj)
+        return nil unless lmda.is_a?(OneGadget::Emulators::Lambda)
 
-        stack if stack.key?(lmda.immi)
+        stack, offset = processor.resolve_address(lmda)
+        return nil unless stack
+        return stack if lmda.deref_count.zero? && OneGadget::ABI.stack_register?(lmda.obj)
+
+        stack if stack.key?(offset)
       end
 
-      # Handle the case where +argv_ptr+ points into the stack, so the +argv+ entries can be read off it.
-      # @param [OneGadget::Emulators::Lambda] argv_ptr The pointer to the argv array
-      #   (a stack register, zero dereference). See {#check_argv}.
+      # Handle the case where +argv_ptr+ points into memory this candidate wrote,
+      # so the +argv+ entries can be read off it.
+      # @param [OneGadget::Emulators::Lambda] argv_ptr The pointer to the argv array. See {#check_argv}.
       # @return [String, nil, false] The same three-way contract as {#check_argv},
       #   which returns this value unchanged: a constraint, +nil+ (already valid),
       #   or +false+ (drop the gadget).
       def check_stack_argv(processor, argv_ptr, allow_null)
-        stack = processor.get_corresponding_stack(argv_ptr.obj)
+        stack, offset = processor.resolve_address(argv_ptr)
         # A stack register we don't track a stack for (the frame pointer):
         # fall back to treating it as an opaque pointer.
         return check_nonstack_argv(argv_ptr, allow_null) if stack.nil?
 
-        argv = (0..3).map { |i| stack[argv_ptr.immi + processor.class.bits / 8 * i].to_s }
+        argv = (0..3).map { |i| stack[offset + processor.class.bits / 8 * i].to_s }
 
         # A shell spawned with a fixed "noexec" option never runs a command, so
         # drop the gadget (see this method's @return for the +false+ contract).
@@ -351,8 +351,8 @@ module OneGadget
         return ptr unless ptr.is_a?(OneGadget::Emulators::Lambda) && ptr.deref_count == 1 &&
                           OneGadget::ABI.stack_register?(ptr.obj)
 
-        stack = processor.get_corresponding_stack(ptr.obj)
-        tracked = stack && stack[ptr.immi]
+        stack, offset = processor.resolve_address(ptr.dup.ref!)
+        tracked = stack && stack[offset]
         return ptr unless tracked.is_a?(OneGadget::Emulators::Lambda) && tracked.deref_count.zero?
 
         tracked

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -40,6 +40,25 @@ describe 'one_gadget_amd64' do
       expect(gadget.constraints).to include('writable: (rsp+0xf & 0xfffffffffffffff0)')
     end
 
+    # Both of these build argv in place through a pointer no register names --
+    # 0xc18cd rounds one down (`and rsi, ~0xf`), 0xc1b3d loads one from the frame
+    # -- and then write [ptr] = "sh", [ptr+8] = r15. Tracking those writes is what
+    # replaces the opaque "[ptr] == NULL" disjunct, which the gadget's own store
+    # to argv[0] can never leave true, with the r15 requirement that really is
+    # the caller's to meet.
+    it 'names the argv a gadget builds through a pointer no register names' do
+      path = data_path('libc-2.19-cf699a15caae64f50311fc4655b86dc39a479789.so')
+      by_offset = OneGadget.gadgets(file: path, force_file: true, level: 1, details: true)
+                           .to_h { |g| [g.offset, g] }
+      expect(by_offset[0xc18cd].constraints).to include(
+        'r15 == NULL || {"sh", r15, [(rsi & 0xfffffffffffffff0)+0x10], ' \
+        '[(rsi & 0xfffffffffffffff0)+0x18], ...} is a valid argv'
+      )
+      expect(by_offset[0xc1b3d].constraints).to include(
+        'r15 == NULL || {"sh", r15, [[rbp-0x48]+0x10], [[rbp-0x48]+0x18], ...} is a valid argv'
+      )
+    end
+
     # Regression: a candidate that ran past its terminal execve into the stack-guard
     # epilogue used to yield spurious gadgets whose fs:/[rax-8] constraints crashed
     # score computation at the default level. Halting at the terminal call drops them.


### PR DESCRIPTION
A candidate that rounds a pointer down, or loads one from its frame, and then builds argv in place had those stores go untracked: no register named the base. Its argv read as opaque, offering a NULL disjunct its own store to argv[0] overwrites.