### PR TITLE
Score a masked value as the requirement it is

### DIFF
--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -103,6 +103,11 @@ module OneGadget
         @score ||= constraints.reduce(1.0) { |s, c| s * calculate_score(c) }
       end
 
+      # Every architecture's register names, for {#base_register} to recognise one
+      # by. Keyed for lookup: it is asked once per token of every constraint scored.
+      REGISTER_NAMES = OneGadget::ABI.all.to_h { |reg| [reg, true] }.freeze
+      private_constant :REGISTER_NAMES
+
       private
 
       # REG: OneGadget::ABI.all
@@ -122,9 +127,9 @@ module OneGadget
       # Expr: <Expr> || <Expr>
       def calculate_score(expr)
         return expr.split(' || ').map(&method(:calculate_score)).max if expr.include?(' || ')
+        return 0.95 if stack_alignment?(expr)
 
         case expr
-        when / & 0xf/ then 0.95
         when /GOT address/ then 0.9
         when /^writable/ then calculate_writable_score(expr.sub('writable: ', ''))
         when / == NULL$/ then calculate_null_score(expr.sub(' == NULL', ''))
@@ -139,6 +144,17 @@ module OneGadget
         end
       end
 
+      # Whether +expr+ is the alignment an aligned store imposes (see
+      # {OneGadget::Emulators::X86#inst_movaps}): the stack pointer's low bits
+      # must hold a fixed value, which is free -- the caller picks where the
+      # stack sits. Matched exactly, so a masked value the caller has to arrange
+      # stays the branch relation it is.
+      # @example matches +rsp & 0xf == 0x0+; not +(eax & 0xf000) == 0x2000+
+      def stack_alignment?(expr)
+        reg = expr[/\A(\S+) & 0xf == 0x[0-9a-f]+\z/, 1]
+        !reg.nil? && OneGadget::ABI.stack_register?(reg)
+      end
+
       # Score a branch-derived relational constraint such as +x2 == 0x1+ or
       # +(u64)x0 >= 0x400+: an equality on one specific value is harder than an
       # inequality/range, and a dereferenced left-hand side is harder still.
@@ -146,37 +162,48 @@ module OneGadget
         op = expr[/ (==|!=|<=|>=|<|>) /, 1]
         lhs = expr.split(/ #{Regexp.escape(op)} /, 2).first.sub(/\A\([su]\d+\)/, '')
         base = op == '==' ? 0.4 : 0.6
-        base * 0.9**lhs_deref_count(lhs)
+        base * 0.9**deref_depth(lhs)
       end
 
-      # Dereference depth of a relation's left side, used to weight the score.
-      # A compound expression (e.g. +(a & b)+ from +tst+, +(a + b)+ from +cmn+) is
-      # not a plain lambda and has no dereference, so it scores as depth 0.
-      def lhs_deref_count(lhs)
-        lmda = OneGadget::Emulators::Lambda.parse(lhs)
-        lmda.is_a?(OneGadget::Emulators::Lambda) ? lmda.deref_count : 0
-      rescue OneGadget::Error::Error
-        0
+      # How many dereferences +identity+ is behind, read off the rendering that
+      # produced it -- a lambda emits one +[+ per dereference.
+      # @example deref_depth('[[ebp+0x10]]') #=> 2
+      def deref_depth(identity)
+        identity[/\A\[*/].size
+      end
+
+      # The register +identity+ is derived from: the first one it names, since a
+      # rendering puts its base ahead of whatever is applied to it. +nil+ when it
+      # names none, e.g. a libc-relative +$base+0x10+.
+      # @example base_register('[(rsi & 0xfffffffffffffff0)+0x10]') #=> 'rsi'
+      def base_register(identity)
+        identity.scan(/\w+/).find { |token| REGISTER_NAMES.key?(token) }
+      end
+
+      # Whether +identity+ is a register itself rather than a value derived from
+      # one. Asked of an undereferenced identity, where being the register is
+      # what makes a requirement on it cheap to meet.
+      # @example bare_register?('rax') #=> true
+      # @example bare_register?('rax+0x10'), bare_register?('(rax & 0xf0)') #=> false
+      def bare_register?(identity)
+        identity == base_register(identity)
       end
 
       def calculate_writable_score(identity)
-        lmda = OneGadget::Emulators::Lambda.parse(identity)
-        return 0.81 if lmda.deref_count != 0
+        return 0.81 unless deref_depth(identity).zero?
 
-        OneGadget::ABI.stack_register?(lmda.obj) ? 0.95 : 0.81
+        OneGadget::ABI.stack_register?(base_register(identity)) ? 0.95 : 0.81
       end
 
       def calculate_null_score(identity)
-        # remove <CAST>
-        identity.sub!(/^\([s|u]\d+\)/, '')
-        # Thank God we are already able to parse this
-        lmda = OneGadget::Emulators::Lambda.parse(identity)
+        identity = identity.sub(/\A\([su]\d+\)/, '') # remove <CAST>
+        depth = deref_depth(identity)
         # rax == 0 is easy; rax + 0x10 == 0 is damn hard.
-        return lmda.immi.zero? ? 0.9 : 0.1 if lmda.deref_count.zero?
+        return bare_register?(identity) ? 0.9 : 0.1 if depth.zero?
 
         # [sp+xx] == NULL is easy.
-        base = OneGadget::ABI.stack_register?(lmda.obj) ? 0 : 1
-        0.9**(lmda.deref_count + base)
+        base = OneGadget::ABI.stack_register?(base_register(identity)) ? 0 : 1
+        0.9**(depth + base)
       end
 
       def merge_constraints

--- a/spec/gadget_spec.rb
+++ b/spec/gadget_spec.rb
@@ -120,14 +120,36 @@ constraints:
       expect(new(['x2 == 0x1']).score).to be_within(eps).of 0.4          # equality
       expect(new(['(u64)x0 >= 0x400']).score).to be_within(eps).of 0.6   # inequality
       expect(new(['[x1+0x8] != 0']).score).to be_within(eps).of 0.54     # deref penalised
-      expect(new(['(x3 & 0x10) == 0']).score).to be_within(eps).of 0.4 # bit-test, parses to x3+0x10
-      expect(new(['(x0 & x1) != 0']).score).to be_within(eps).of 0.6 # distinct regs: lhs unparseable
-      expect(new(['(s64)(x0 + 0x10) < 0']).score).to be_within(eps).of 0.6 # cmn compare: lhs unparseable
+      expect(new(['(x3 & 0x10) == 0']).score).to be_within(eps).of 0.4  # bit-test, nothing dereferenced
+      expect(new(['(x0 & x1) != 0']).score).to be_within(eps).of 0.6    # ..and neither is a distinct-register one
+      expect(new(['(s64)(x0 + 0x10) < 0']).score).to be_within(eps).of 0.6 # nor a cmn compare
+    end
+
+    # The stack pointer's low bits holding a fixed value is free -- the caller
+    # picks where the stack sits. A masked *value* renders similarly but is a
+    # requirement the caller has to arrange, and scores as the relation it is.
+    it 'tells stack alignment from a masked value' do
+      expect(new(['rsp & 0xf == 0x0']).score).to be_within(eps).of 0.95
+      expect(new(['sp & 0xf == 0x8']).score).to be_within(eps).of 0.95
+      expect(new(['(eax & 0xf000) == 0x2000']).score).to be_within(eps).of 0.4
+    end
+
+    # A pointer a gadget masks before writing through is scored by what it is
+    # derived from: rounding the stack pointer down still lands on the stack,
+    # while rounding an attacker register down is as hard as the register was.
+    it 'scores a masked pointer by the register it derives from' do
+      expect(new(['writable: (rsp+0xf & 0xfffffffffffffff0)']).score).to be_within(eps).of 0.95
+      expect(new(['writable: (rax & 0xfffffffffffffff0)']).score).to be_within(eps).of 0.81
+      expect(new(['{"sh", r15, [(rsi & 0xfffffffffffffff0)+0x10], ...} is a valid argv']).score)
+        .to be_within(eps).of 0.2
     end
 
     it 'level 3' do
       expect(new(['[[x4+0xad0]] == NULL']).score).to be_within(eps).of 0.9**3
       expect(new(['x4+0xad0 == NULL']).score).to be_within(eps).of 0.1
+      # Both loads count: the offset one nests in the lambda representation, so
+      # only the rendering states the depth the caller actually has to arrange.
+      expect(new(['[[x0+0x438]+0xe8] == 0x0']).score).to be_within(eps).of 0.4 * 0.9**2
     end
 
     it 'more than one' do


### PR DESCRIPTION
The stack-alignment case matched any constraint containing " & 0xf", so every mask the `and` modelling emits was scored 0.95 unexamined -- a `writable: (rax & 0xfffffffffffffff0)`, a bit-test relation, even an argv literal that merely mentioned one.

Match the alignment constraint exactly, and score the rest for what they are. The scorers now read the rendering they are given rather than round-tripping it through the emulator's operand parser, which could not take a mask at all and made two of the three raise on one.

26 constraint scores change; no gadget's output does, at any level.