### PR TITLE
Drop a gadget whose list meets an easier gadget's

### DIFF
--- a/lib/one_gadget/fetchers.rb
+++ b/lib/one_gadget/fetchers.rb
@@ -62,14 +62,14 @@ module OneGadget
                .sort_by { |g| [g.offset, g.constraints.size] }
       end
 
-      # Unique, remove gadgets with harder constraints.
+      # Unique, remove gadgets whose constraints already meet an easier gadget's
+      # (see {OneGadget::Gadget::Gadget#met_by?}): that one is the better answer,
+      # and this one asks the reader for strictly more.
       def trim_gadgets(gadgets)
         gadgets = gadgets.uniq(&:constraints).sort_by { |g| g.constraints.size }
         res = []
         gadgets.each_with_index do |g, i|
-          res << g unless i.times.any? do |j|
-            (gadgets[j].constraints - g.constraints).empty?
-          end
+          res << g unless i.times.any? { |j| gadgets[j].met_by?(g) }
         end
         # The same offset can reach the call via more than one branch direction;
         # list it once, keeping the easiest (fewest-constraint) variant.

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -103,10 +103,31 @@ module OneGadget
         @score ||= constraints.reduce(1.0) { |s, c| s * calculate_score(c) }
       end
 
+      # Whether +other+ asks for everything this gadget asks for, so listing this
+      # one beside it tells the reader nothing new. Each constraint here has to be
+      # met by +other+'s list: named there, or -- for one that offers several
+      # options -- an option of it required there outright.
+      # @param [Gadget] other
+      # @return [Boolean]
+      # @example An option required outright meets the constraint offering it.
+      #   met_by?(other) # where this asks "r8 == NULL || (u16)[r8] == 0x0"
+      #                  # and +other+ asks "(u16)[r8] == 0x0"
+      def met_by?(other)
+        constraints.all? do |con|
+          other.constraints.include?(con) ||
+            con.split(DISJUNCTION).any? { |option| other.constraints.include?(option) }
+        end
+      end
+
       # Every architecture's register names, for {#base_register} to recognise one
       # by. Keyed for lookup: it is asked once per token of every constraint scored.
       REGISTER_NAMES = OneGadget::ABI.all.to_h { |reg| [reg, true] }.freeze
       private_constant :REGISTER_NAMES
+
+      # What separates the options of a constraint that can be met in more than
+      # one way.
+      DISJUNCTION = ' || '
+      private_constant :DISJUNCTION
 
       private
 

--- a/spec/gadget_spec.rb
+++ b/spec/gadget_spec.rb
@@ -86,6 +86,33 @@ constraints:
     end
   end
 
+  context 'met_by?' do
+    def gadget(cons)
+      OneGadget::Gadget::Gadget.new(0, constraints: cons)
+    end
+
+    it 'holds when the other list names every constraint' do
+      easier = gadget(['rax == NULL'])
+      harder = gadget(['rax == NULL', 'writable: rbx'])
+      expect(easier.met_by?(harder)).to be true
+      expect(harder.met_by?(easier)).to be false
+    end
+
+    # libc-2.31 0x51e2b offers "rbp == NULL || (u16)[rbp] == 0x0"; 0x51e23 asks
+    # for the second option outright, so it asks for everything 0x51e2b does.
+    it 'holds when an option is required outright' do
+      easier = gadget(['rbp == NULL || (u16)[rbp] == 0x0'])
+      harder = gadget(['writable: rbp', '(u16)[rbp] == 0x0'])
+      expect(easier.met_by?(harder)).to be true
+    end
+
+    it 'does not hold when only a different option is required' do
+      easier = gadget(['rbp == NULL || (u16)[rbp] == 0x0'])
+      harder = gadget(['writable: rbp', '[rbp+0x8] == 0x0'])
+      expect(easier.met_by?(harder)).to be false
+    end
+  end
+
   context 'score' do
     def new(cons)
       OneGadget::Gadget::Gadget.new(0, constraints: cons)

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -12,7 +12,7 @@ describe 'one_gadget_amd64' do
     it 'libc-2.19' do
       path = data_path('libc-2.19-cf699a15caae64f50311fc4655b86dc39a479789.so')
       expect(OneGadget.gadgets(file: path, force_file: true, level: 1))
-        .to eq [0x46421, 0x46428, 0x4643b, 0x46444, 0x46449, 0x46450, 0x4647c,
+        .to eq [0x46421, 0x46428, 0x4647c,
                 0xc18c8, 0xc18cd, 0xc18d1, 0xc18d8, 0xc1b3d, 0xc1ba3, 0xc1bf2, 0xc1ca7,
                 0xe4968, 0xe5765, 0xe5771,
                 0xe6527, 0xe652e, 0xe6532, 0xe653e, 0xe6543, 0xe654a,


### PR DESCRIPTION
trim_gadgets kept a gadget unless another one's constraints appeared verbatim in its own list, so a constraint offering several options only counted when the harder gadget happened to spell it the same way. A gadget requiring "rsi == NULL" outright asks for everything a gadget offering "[rsi] == NULL || rsi == NULL || rsi is a valid argv" asks for, and more -- listing it beside the easier one tells the reader nothing.

Ask whether each constraint is met rather than named: an option required outright meets the constraint offering it.

Eight gadgets leave level 1 on the 21 fixtures (amd64 2.19 and 2.26, all of them execve gadgets asking three registers be NULL where a two-constraint gadget in the same libc asks less). Levels 0 and 2 are byte-identical.