### PR TITLE
Stop redoing per-candidate work once per window

### DIFF
--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -88,16 +88,29 @@ module OneGadget
       # @return [(Instruction, Array<String>)]
       #   The parsing result.
       def parse(cmd)
-        # instructions is a constant set; build the array (and a mnemonic index)
-        # once instead of re-allocating it for every line.
-        @inst_index ||= instructions.each_with_object({}) { |i, h| h[i.inst] ||= i }
+        list, index = self.class.instruction_table { instructions }
         mnem = cmd[/\A[0-9a-f]+:\s*(\S+)/, 1] || cmd[/\A\s*(\S+)/, 1]
-        inst = @inst_index[mnem]
+        inst = index[mnem]
         # Fall back to the original scan for any mnemonic that isn't a bare word.
-        inst ||= (@inst_list ||= instructions).find { |i| i.match?(cmd) }
+        inst ||= list.find { |i| i.match?(cmd) }
         raise Error::UnsupportedInstructionError, "Not implemented instruction in #{cmd}" if inst.nil?
 
         [inst, inst.fetch_args(cmd)]
+      end
+
+      class << self
+        # The architecture's supported instructions, and the same set indexed by
+        # mnemonic, built on first use and shared by every emulator of that
+        # architecture: the set is fixed, while an emulator is made for each of the
+        # thousands of windows a candidate yields.
+        # @yieldreturn [Array<Instruction>] The table, asked for only on first use.
+        # @return [(Array<Instruction>, Hash{String => Instruction})]
+        def instruction_table
+          @instruction_table ||= begin
+            list = yield
+            [list, list.each_with_object({}) { |i, h| h[i.inst] ||= i }]
+          end
+        end
       end
 
       # Process one command, without raising any exceptions.

--- a/lib/one_gadget/fetchers/arm.rb
+++ b/lib/one_gadget/fetchers/arm.rb
@@ -134,14 +134,31 @@ module OneGadget
       REG = /r\d+|sl|fp|ip|lr/
       private_constant :REG
 
+      # A register-offset load, +[rB, rX]+.
+      REG_OFFSET_LOAD = /\[(#{REG}),\s*(?:#{REG})\]/
+      private_constant :REG_OFFSET_LOAD
+
       # Collect the registers used as a base in a register-offset load (+[rB, rX]+);
       # in glibc's PIC these +rB+ are the GOT base holding +$base + got+.
       # @example
       #   got_base_registers(['88ab2: ldr r2, [r1, r2]'])
       #   #=> ['r1']
       def got_base_registers(cmds)
-        cmds.flat_map { |c| c.scan(/\[(#{REG}),\s*(?:#{REG})\]/) }
+        cmds.flat_map { |c| c.scan(REG_OFFSET_LOAD) }
             .flatten.uniq
+      end
+
+      # The patterns naming one register: what uses it as a load base, and the
+      # +ldr+/+add+ pair that establishes it. Built once per register -- they are
+      # asked of every line of every window a candidate yields.
+      # @param [String] reg
+      # @return [Hash{Symbol => Regexp}]
+      def reg_patterns(reg)
+        (@reg_patterns ||= {})[reg] ||= {
+          use: /\[#{reg},\s*(?:#{REG})\]/,
+          add: /:\s*add(?:\.w)?\s+#{reg}, pc$/,
+          ldr: /:\s*ldr(?:\.w)?\s+#{reg}, \[pc[,\]]/
+        }
       end
 
       # Whether the candidate builds +reg+'s base itself, before the +[reg, rX]+
@@ -151,9 +168,10 @@ module OneGadget
       # constraint naming the register's *entry* value.
       # @example arm-2.27's +0x73f2a+, whose first instruction is +add r3, pc+
       def window_establishes?(reg, cmds)
-        use = cmds.index { |c| c.match?(/\[#{reg},\s*(?:#{REG})\]/) } or return false
+        pattern = reg_patterns(reg)
+        use = cmds.index { |c| c.match?(pattern[:use]) } or return false
 
-        cmds[0...use].any? { |c| c.match?(/:\s*add(?:\.w)?\s+#{reg}, pc$/) }
+        cmds[0...use].any? { |c| c.match?(pattern[:add]) }
       end
 
       # Prime +emu+ with every GOT base register the candidate relies on, by
@@ -179,18 +197,25 @@ module OneGadget
       # Locate the +ldr reg, [pc, ...]; add reg, pc+ pair that establishes +reg+
       # before address +before+. Returns the two objdump lines, or +nil+.
       def got_setup_lines(reg, before)
+        (@got_setup ||= {})[[reg, before]] ||= find_got_setup_lines(reg, before)
+      end
+
+      # {#got_setup_lines} without the memo: overlapping candidates ask the same
+      # register at the same address again and again, and the answer only depends
+      # on the disassembly.
+      def find_got_setup_lines(reg, before)
         pos = disasm_index[before]
         return if pos.nil?
 
-        add_re = /:\s*add(?:\.w)?\s+#{reg}, pc$/
-        add_at = pos.downto([0, pos - 400].max).find { |i| disasm_lines[i].match?(add_re) }
+        lines = disasm_lines
+        pattern = reg_patterns(reg)
+        add_at = pos.downto([0, pos - 400].max).find { |i| lines[i].match?(pattern[:add]) }
         return if add_at.nil?
 
-        ldr_re = /:\s*ldr(?:\.w)?\s+#{reg}, \[pc[,\]]/
-        ldr_at = add_at.downto([0, add_at - 4].max).find { |i| disasm_lines[i].match?(ldr_re) }
+        ldr_at = add_at.downto([0, add_at - 4].max).find { |i| lines[i].match?(pattern[:ldr]) }
         return if ldr_at.nil?
 
-        [disasm_lines[ldr_at], disasm_lines[add_at]]
+        [lines[ldr_at], lines[add_at]]
       end
 
       def branch_lead_chars

--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -67,9 +67,7 @@ module OneGadget
         # and everything after it) recurs across candidates; emulate each once.
         seen = {}
         candidates.each do |cand|
-          lines = cand.lines
-          (lines.size - 2).downto(0) do |i|
-            suffix = executed_window(lines[i..])
+          executed_windows(cand.lines) do |suffix|
             next if seen.key?(key = suffix.join)
 
             seen[key] = true
@@ -80,16 +78,26 @@ module OneGadget
         gadgets
       end
 
-      # The part of +lines+ that runs: emulation ends at the terminal call, so
-      # anything past it never executes. A suffix reaches beyond one when the
-      # function holds several terminal calls and the candidate was walked back
-      # from a later one. Bounding it here lets everything downstream -- {#emulate}
-      # and its overrides, the dedup key above -- read a window as executed code.
-      # @param [Array<String>] lines A candidate suffix.
-      # @return [Array<String>]
-      def executed_window(lines)
-        stop = lines.index { |line| terminal_call_line?(line) }
-        stop ? lines[..stop] : lines
+      # Every suffix of +lines+ -- a start line and everything after it, longest
+      # last -- cut down to the part that runs: emulation ends at the terminal
+      # call, so anything past one never executes. A suffix reaches beyond a
+      # terminal call when the function holds several and the candidate was walked
+      # back from a later one. Bounding each window here lets everything
+      # downstream -- {#emulate} and its overrides, the dedup key in {#find} --
+      # read a window as executed code.
+      #
+      # Each line is classified once per candidate rather than once per suffix
+      # containing it: walking the start backwards, the first terminal call at or
+      # after it only moves when the start is itself one.
+      # @param [Array<String>] lines One candidate, as a line list.
+      # @yieldparam [Array<String>] window
+      # @return [void]
+      def executed_windows(lines)
+        stop = lines.size - 1 if terminal_call_line?(lines.last)
+        (lines.size - 2).downto(0) do |i|
+          stop = i if terminal_call_line?(lines[i])
+          yield(stop ? lines[i..stop] : lines[i..])
+        end
       end
 
       # Whether +line+ is the call that ends a gadget, by the same rule the emulator
@@ -470,7 +478,7 @@ module OneGadget
 
       # Run a window through a fresh emulator, stopping at the first line it can't
       # process (an unsupported instruction, or the terminal call that ends the
-      # gadget). +cmds+ is an executed window (see {#executed_window}): every line
+      # gadget). +cmds+ is an executed window (see {#executed_windows}): every line
       # in it runs, so an override may read it as evidence of what the path does.
       # @param [Array<String>] cmds
       # @return [OneGadget::Emulators::Processor]
@@ -486,8 +494,15 @@ module OneGadget
       end
 
       def str_offset(str)
-        File.binread(file).index("#{str}\x00") ||
+        file_bytes.index("#{str}\x00") ||
           raise(Error::ArgumentError, "File #{file.inspect} doesn't contain string #{str.inspect}, not glibc?")
+      end
+
+      # The target's bytes, read once: a gadget names fixed strings by file offset,
+      # and every argv entry of every candidate asks for them again.
+      # @return [String]
+      def file_bytes
+        @file_bytes ||= File.binread(file)
       end
 
       # Render one argv/envp entry for a constraint. A libc global that points to a
@@ -510,7 +525,7 @@ module OneGadget
       def global_str_content(element)
         off = string_file_offset(element) or return nil
 
-        bytes = File.binread(file)
+        bytes = file_bytes
         return nil unless off.between?(0, bytes.size - 1)
 
         stop = bytes.index("\x00", off) or return nil
@@ -604,8 +619,8 @@ module OneGadget
       def branch_aware_candidates(&)
         cands = []
         re = /#{terminal_call_regexp}/
-        disasm_lines.each_index do |idx|
-          next unless disasm_lines[idx].match?(re)
+        disasm_lines.each_with_index do |line, idx|
+          next unless line.match?(re)
 
           back_walk(idx, 0, Set.new, []) { |lines| cands << lines.join("\n") }
         end
@@ -664,8 +679,7 @@ module OneGadget
       def branch_pred_map
         @branch_pred_map ||= Base.cached(:branch_pred, @objdump.command) do
           lead = branch_lead_regex
-          disasm_lines.each_index.with_object(Hash.new { |h, k| h[k] = [] }) do |i, map|
-            line = disasm_lines[i]
+          disasm_lines.each_with_index.with_object(Hash.new { |h, k| h[k] = [] }) do |(line, i), map|
             # Cheap precompiled reject (no per-line allocation) before the full test.
             next unless line.match?(lead)
             next unless %i[conditional unconditional].include?(branch_kind(line))


### PR DESCRIPTION
A candidate is emulated once for every suffix of it, so anything computed from the whole window is computed again for each of the thousands a libc yields. Four such repeats, none of which change what is listed:

* The executed window was found by scanning each suffix for its terminal call, classifying every line once per suffix containing it. Walking the start backwards, the first terminal call at or after it only moves when the start is itself one, so each line is classified once per candidate.
* arm rebuilt a Regexp per line to find register-offset loads, and two more per register to find the ldr/add pair that established a GOT base -- then scanned up to 400 lines of disassembly for that pair again for every window asking the same register at the same address.
* File.binread re-read the whole libc for each argv entry naming a fixed string.
* The instruction table was rebuilt for every emulator, and two whole-file scans fetched each line by index off a memoized accessor.

Level 0 on the 21 fixtures: aarch64-2.43 3.9s -> 2.3s, arm-2.43 4.0s -> 1.7s, arm-2.39 3.3s -> 1.6s, and the whole corpus 42.5s -> 29.4s, of which 2.7s is interpreter startup either way. Output is byte-identical at levels 0, 1 and 2.