### PR TITLE
Nothing falls through into the first line of a window

### DIFF
--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -681,7 +681,9 @@ module OneGadget
       def predecessors(idx)
         (@predecessors ||= {})[idx] ||= begin
           preds = []
-          if idx.positive?
+          # Nothing falls through into the first line of a window: the line before
+          # it is the last of another window, a different part of the binary.
+          if idx.positive? && !window_starts.key?(idx)
             kind = branch_kind(disasm_lines[idx - 1])
             preds << [idx - 1, kind == :conditional] unless %i[unconditional terminator].include?(kind)
           end
@@ -749,10 +751,24 @@ module OneGadget
       def branch_lead_chars; raise NotImplementedError
       end
 
-      # The target's full objdump disassembly as stripped +"ADDR: insn"+ lines,
-      # cached for the lifetime of the fetcher.
+      # The target's objdump disassembly as stripped +"ADDR: insn"+ lines.
       def disasm_lines
-        @disasm_lines ||= Base.cached(:disasm, @objdump.command) do
+        disassembly[:lines]
+      end
+
+      # Where in {#disasm_lines} each window begins, keyed for lookup. Empty when
+      # the whole file was disassembled, since then every line does follow the one
+      # before it.
+      # @return [Hash{Integer => true}]
+      def window_starts
+        disassembly[:starts]
+      end
+
+      # The disassembly and the shape it was taken in, cached (per objdump command)
+      # for the lifetime of the fetcher.
+      # @return [Hash{Symbol => Array<String>, Hash}]
+      def disassembly
+        @disassembly ||= Base.cached(:disasm, @objdump.command) do
           sites = terminal_call_sites
           sites.nil? || sites.empty? ? full_disasm : windowed_disasm(sites)
         end
@@ -760,7 +776,7 @@ module OneGadget
 
       # Disassemble the whole file (the exhaustive default).
       def full_disasm
-        objdump_lines
+        { lines: objdump_lines, starts: {} }
       end
 
       # Disassemble only [call-WINDOW_BACK, call+WINDOW_FWD] around each call site,
@@ -768,7 +784,12 @@ module OneGadget
       # a full disassembly (the win on the slow-to-objdump Thumb-2 arm libcs).
       def windowed_disasm(sites)
         windows = sites.sort.map { |a| [[a - WINDOW_BACK, 0].max, a + WINDOW_FWD] }
-        merge_ranges(windows).flat_map { |lo, hi| objdump_lines(start: lo, stop: hi) }
+        starts = {}
+        lines = merge_ranges(windows).each_with_object([]) do |(lo, hi), acc|
+          starts[acc.size] = true
+          acc.concat(objdump_lines(start: lo, stop: hi))
+        end
+        { lines:, starts: }
       end
 
       # Merge a list of sorted [lo, hi] ranges, coalescing any that overlap.

--- a/spec/fetchers/base_spec.rb
+++ b/spec/fetchers/base_spec.rb
@@ -24,6 +24,22 @@ describe OneGadget::Fetchers::Base do
     end
   end
 
+  describe '#predecessors' do
+    # A windowed disassembly is a run of separate regions, so the line before the
+    # first of a window is the last of the window before it -- a different part of
+    # the binary, which nothing follows from.
+    it 'does not fall through into the first line of a window' do
+      allow(fetcher).to receive_messages(disasm_lines: ['1000: mov rax,rbx', '2000: mov rcx,rdx'],
+                                         branch_pred_map: {})
+      allow(fetcher).to receive(:window_starts).and_return({ 0 => true })
+      expect(fetcher.send(:predecessors, 1)).to eq [[0, false]]
+
+      fetcher.instance_variable_set(:@predecessors, nil)
+      allow(fetcher).to receive(:window_starts).and_return({ 0 => true, 1 => true })
+      expect(fetcher.send(:predecessors, 1)).to be_empty
+    end
+  end
+
   describe '#resolve_suffix' do
     # An exotic path can leave an argument register the resolver cannot evaluate,
     # which raises rather than returning nil; such a candidate simply isn't a gadget.


### PR DESCRIPTION
A windowed disassembly is a run of separate regions of the binary, but the walk read it as one: the predecessor of a line was the line before it in the array, which at the start of a window is the last line of the window before it. The path then stitched two unrelated regions together and the emulator ran it as straight-line code.

Carry the indexes where each window begins, and let nothing fall through into one. On arm-2.43 with a deliberately tiny 0x100 window that removes six gadgets the full disassembly never finds; at the shipped window size nothing on the 21 fixtures changes, at any level. The wrong edge is there either way, and gets easier to hit the more architectures window.