### PR TITLE
Disassemble a libc's windows at the same time

### DIFF
--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -800,10 +800,15 @@ module OneGadget
       # a full disassembly (the win on the slow-to-objdump Thumb-2 arm libcs).
       def windowed_disasm(sites)
         windows = sites.sort.map { |a| [[a - WINDOW_BACK, 0].max, a + WINDOW_FWD] }
+        # One objdump per window, all at once: they are separate processes that
+        # wait on each other for nothing, and a libc comes to a handful of windows.
+        disassembled = merge_ranges(windows)
+                       .map { |lo, hi| Thread.new { objdump_lines(start: lo, stop: hi) } }
+                       .map(&:value)
         starts = {}
-        lines = merge_ranges(windows).each_with_object([]) do |(lo, hi), acc|
+        lines = disassembled.each_with_object([]) do |window, acc|
           starts[acc.size] = true
-          acc.concat(objdump_lines(start: lo, stop: hi))
+          acc.concat(window)
         end
         { lines:, starts: }
       end


### PR DESCRIPTION
A libc comes to a handful of windows around its terminal calls, each disassembled by its own objdump process -- processes that wait on each other for nothing, but were run one after another. Start them together and take the results in order.

The slowest window is what it costs now instead of their sum: arm-2.43's five windows were 0.27s and are 0.11s. Level 0: arm-2.43 1.08s -> 0.86s, arm-2.39 0.97s -> 0.78s, aarch64-2.43 0.78s -> 0.67s, and the whole corpus 10.4s -> 9.2s. Output is byte-identical at levels 0, 1 and 2.