### PR TITLE
Ask whether an operand is a number without raising

### DIFF
--- a/lib/one_gadget/emulators/lambda.rb
+++ b/lib/one_gadget/emulators/lambda.rb
@@ -156,9 +156,11 @@ module OneGadget
         #   Lambda.parse('[x0, -104]')
         #   #=> #<Lambda @obj='x0', @immi=-104, @deref_count=1>
         def parse(argument, predefined: {})
-          arg = argument.dup
+          arg = argument
           return 0 if arg.empty? || arg == '!'
-          return Integer(arg) if OneGadget::Helper.integer?(arg)
+
+          literal = Integer(arg, exception: false)
+          return literal unless literal.nil?
 
           # nested []
           if arg[0] == '['

--- a/lib/one_gadget/helper.rb
+++ b/lib/one_gadget/helper.rb
@@ -250,9 +250,7 @@ module OneGadget
     #   Helper.integer? '0xheapoverflow'
     #   #=> false
     def integer?(str)
-      true if Integer(str)
-    rescue ArgumentError, TypeError
-      false
+      !Integer(str, exception: false).nil?
     end
 
     # Cross-platform way of finding an executable in +$PATH+.


### PR DESCRIPTION
Reading an operand asked "is this an integer?" by parsing it and catching the failure, then parsed it again when it succeeded. Most operands are registers, so most of those calls raised -- tens of thousands per libc, on the hottest path the emulator has.

Ask for the number and look at what comes back. Reading an operand into a value goes from 0.133s to 0.080s on aarch64-2.43, and the duplicated parse of a literal goes with it.

Level 0: aarch64-2.43 0.78s -> 0.64s, arm-2.43 1.08s -> 0.97s, arm-2.39 0.97s -> 0.91s, and the whole corpus 10.4s -> 9.9s. Output is byte-identical at levels 0, 1 and 2.