### PR TITLE
Say what each output level shows, from files anyone has

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,18 @@ $ one_gadget
 ```
 
 ```bash
-$ one_gadget /lib/x86_64-linux-gnu/libc.so.6
-# 0xe3afe execve("/bin/sh", r15, r12)
+$ one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so
+# 0xe3b2e execve("/bin/sh", r15, r12)
 # constraints:
 #   [r15] == NULL || r15 == NULL || r15 is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3b01 execve("/bin/sh", r15, rdx)
+# 0xe3b31 execve("/bin/sh", r15, rdx)
 # constraints:
 #   [r15] == NULL || r15 == NULL || r15 is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
 #
-# 0xe3b04 execve("/bin/sh", rsi, rdx)
+# 0xe3b34 execve("/bin/sh", rsi, rdx)
 # constraints:
 #   [rsi] == NULL || rsi == NULL || rsi is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
@@ -125,35 +125,35 @@ you will have at least 1/16 chance of success.
 Reorder gadgets according to the distance of given functions.
 
 ```bash
-$ one_gadget /lib/x86_64-linux-gnu/libc.so.6 --near exit,mkdir
-# [OneGadget] Gadgets near exit(0x46a40):
-# 0xe3afe execve("/bin/sh", r15, r12)
+$ one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so --near exit,mkdir
+# [OneGadget] Gadgets near exit(0x46a70):
+# 0xe3b2e execve("/bin/sh", r15, r12)
 # constraints:
 #   [r15] == NULL || r15 == NULL || r15 is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3b01 execve("/bin/sh", r15, rdx)
+# 0xe3b31 execve("/bin/sh", r15, rdx)
 # constraints:
 #   [r15] == NULL || r15 == NULL || r15 is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
 #
-# 0xe3b04 execve("/bin/sh", rsi, rdx)
+# 0xe3b34 execve("/bin/sh", rsi, rdx)
 # constraints:
 #   [rsi] == NULL || rsi == NULL || rsi is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
 #
-# [OneGadget] Gadgets near mkdir(0x10de70):
-# 0xe3b04 execve("/bin/sh", rsi, rdx)
+# [OneGadget] Gadgets near mkdir(0x10dc80):
+# 0xe3b34 execve("/bin/sh", rsi, rdx)
 # constraints:
 #   [rsi] == NULL || rsi == NULL || rsi is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
 #
-# 0xe3b01 execve("/bin/sh", r15, rdx)
+# 0xe3b31 execve("/bin/sh", r15, rdx)
 # constraints:
 #   [r15] == NULL || r15 == NULL || r15 is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
 #
-# 0xe3afe execve("/bin/sh", r15, r12)
+# 0xe3b2e execve("/bin/sh", r15, r12)
 # constraints:
 #   [r15] == NULL || r15 == NULL || r15 is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
@@ -164,306 +164,319 @@ $ one_gadget /lib/x86_64-linux-gnu/libc.so.6 --near exit,mkdir
 
 Regular expression is acceptable.
 ```bash
-$ one_gadget /lib/x86_64-linux-gnu/libc.so.6 --near 'write.*' --raw
-# [OneGadget] Gadgets near writev(0x114690):
-# 932612 932609 932606
+$ one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so --near 'write.*' --raw
+# [OneGadget] Gadgets near writev(0x1144a0):
+# 932660 932657 932654
 #
-# [OneGadget] Gadgets near write(0x10e280):
-# 932612 932609 932606
+# [OneGadget] Gadgets near write(0x10e090):
+# 932660 932657 932654
 #
 
 ```
 
 Pass an ELF file as the argument, OneGadget will take all GOT functions for processing.
 ```bash
-$ one_gadget /lib/x86_64-linux-gnu/libc.so.6 --near spec/data/test_near_file.elf --raw
-# [OneGadget] Gadgets near exit(0x46a40):
-# 932606 932609 932612
+$ one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so --near spec/data/test_near_file.elf --raw
+# [OneGadget] Gadgets near exit(0x46a70):
+# 932654 932657 932660
 #
-# [OneGadget] Gadgets near puts(0x84420):
-# 932606 932609 932612
+# [OneGadget] Gadgets near puts(0x84450):
+# 932654 932657 932660
 #
-# [OneGadget] Gadgets near printf(0x61c90):
-# 932606 932609 932612
+# [OneGadget] Gadgets near printf(0x61cc0):
+# 932654 932657 932660
 #
-# [OneGadget] Gadgets near strlen(0x9f630):
-# 932606 932609 932612
+# [OneGadget] Gadgets near strlen(0x9f660):
+# 932654 932657 932660
 #
-# [OneGadget] Gadgets near __cxa_finalize(0x46f10):
-# 932606 932609 932612
+# [OneGadget] Gadgets near __cxa_finalize(0x46f40):
+# 932654 932657 932660
 #
-# [OneGadget] Gadgets near __libc_start_main(0x23f90):
-# 932606 932609 932612
+# [OneGadget] Gadgets near __libc_start_main(0x23fc0):
+# 932654 932657 932660
 #
 
 ```
 
-#### Show All Gadgets
+#### Show More Gadgets
 
-Sometimes `one_gadget` finds too many gadgets to show them in one screen,
-by default gadgets would be filtered automatically *according to the difficulty of constraints*.
+A libc holds far more gadgets than fit on a screen, and most of them ask more of you
+than a handful of others do. `--level` chooses how much of what was found to show.
 
-Use option `--level 1` to show all gadgets found instead of only those with higher probabilities.
+| Level | Shows | Use it when |
+| --- | --- | --- |
+| `0` (default) | the few gadgets whose constraints are easiest to arrange | always, first |
+| `1` | every gadget, one line per address, minus any that asks for everything an easier one asks for and more | none of the level-0 gadgets fit what you control |
+| `2` | everything found, including an address listed once per set of constraints it can be reached under | you want to see every way in, including the awkward ones |
+
+Level 1 drops a gadget when an easier one already asks for everything it does; level 0
+then scores what is left by how hard its constraints look and keeps only the best few;
+level 2 drops nothing. On the glibc 2.31 below that is 3, 35 and 97 entries -- the last
+over 96 addresses, since one of them is reachable two ways with different requirements.
+
+Level 2 also reads the libc you point at directly, where the levels below it answer
+from the pre-built gadget database when it knows the file's BuildID; the database only
+stores the trimmed set. Pass `-f` to search the file at every level.
 
 ```bash
-$ one_gadget /lib/x86_64-linux-gnu/libc.so.6 --level 1
-# 0x51dfb posix_spawn(rsp+0xc, "/bin/sh", 0, rbp, rsp+0x50, environ)
+$ one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so --level 1
+# 0x51e2b posix_spawn(rsp+0xc, "/bin/sh", 0, rbp, rsp+0x50, environ)
 # constraints:
 #   address rsp+0x60 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   {"sh", "-c", rbx, NULL} is a valid argv
-#   rbp == NULL || (u16)[rbp] == NULL
+#   rbp == NULL || (u16)[rbp] == 0x0
 #
-# 0x51e02 posix_spawn(rsp+0xc, "/bin/sh", 0, rbp, rsp+0x50, environ)
+# 0x51e32 posix_spawn(rsp+0xc, "/bin/sh", 0, rbp, rsp+0x50, environ)
 # constraints:
 #   address rsp+0x60 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   rax == NULL || {"sh", rax, rbx, NULL} is a valid argv
-#   rbp == NULL || (u16)[rbp] == NULL
+#   rbp == NULL || (u16)[rbp] == 0x0
 #
-# 0x51e09 posix_spawn(rsp+0xc, "/bin/sh", 0, rbp, rsp+0x50, environ)
+# 0x51e39 posix_spawn(rsp+0xc, "/bin/sh", 0, rbp, rsp+0x50, environ)
 # constraints:
 #   address rsp+0x60 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   rcx == NULL || {rcx, rax, rbx, NULL} is a valid argv
-#   rbp == NULL || (u16)[rbp] == NULL
+#   rbp == NULL || (u16)[rbp] == 0x0
 #
-# 0x51e10 posix_spawn(rsp+0xc, "/bin/sh", rdx, rbp, rsp+0x50, environ)
+# 0x51e40 posix_spawn(rsp+0xc, "/bin/sh", rdx, rbp, rsp+0x50, environ)
 # constraints:
 #   address rsp+0x60 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   rcx == NULL || {rcx, (u64)xmm1, rbx, NULL} is a valid argv
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rbp == NULL || (u16)[rbp] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rbp == NULL || (u16)[rbp] == 0x0
 #
-# 0x51e15 posix_spawn(rsp+0xc, "/bin/sh", rdx, rbp, rsp+0x50, environ)
+# 0x51e45 posix_spawn(rsp+0xc, "/bin/sh", rdx, rbp, rsp+0x50, environ)
 # constraints:
 #   address rsp+0x60 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   (u64)xmm0 == NULL || {(u64)xmm0, (u64)xmm1, rbx, NULL} is a valid argv
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rbp == NULL || (u16)[rbp] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rbp == NULL || (u16)[rbp] == 0x0
 #
-# 0x51e25 posix_spawn(rdi, "/bin/sh", rdx, rbp, rsp+0x50, [rax])
+# 0x51e55 posix_spawn(rdi, "/bin/sh", rdx, rbp, rsp+0x50, [rax])
 # constraints:
 #   address rsp+0x60 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   (u64)xmm0 == NULL || {(u64)xmm0, (u64)(xmm0 >> 64), rbx, NULL} is a valid argv
 #   [[rax]] == NULL || [rax] == NULL || [rax] is a valid envp
 #   rdi == NULL || writable: rdi
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rbp == NULL || (u16)[rbp] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rbp == NULL || (u16)[rbp] == 0x0
 #
-# 0x51e2a posix_spawn(rdi, "/bin/sh", rdx, rbp, r8, [rax])
+# 0x51e5a posix_spawn(rdi, "/bin/sh", rdx, rbp, r8, [rax])
 # constraints:
 #   address rsp+0x60 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   [r8] == NULL || r8 is a valid argv
 #   [[rax]] == NULL || [rax] == NULL || [rax] is a valid envp
 #   rdi == NULL || writable: rdi
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rbp == NULL || (u16)[rbp] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rbp == NULL || (u16)[rbp] == 0x0
 #
-# 0x51e2d posix_spawn(rdi, "/bin/sh", rdx, rcx, r8, [rax])
+# 0x51e5d posix_spawn(rdi, "/bin/sh", rdx, rcx, r8, [rax])
 # constraints:
 #   address rsp+0x60 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   [r8] == NULL || r8 is a valid argv
 #   [[rax]] == NULL || [rax] == NULL || [rax] is a valid envp
 #   rdi == NULL || writable: rdi
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rcx == NULL || (u16)[rcx] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rcx == NULL || (u16)[rcx] == 0x0
 #
-# 0x51e32 posix_spawn(rdi, "/bin/sh", rdx, rcx, r8, [rax])
+# 0x51e62 posix_spawn(rdi, "/bin/sh", rdx, rcx, r8, [rax])
 # constraints:
 #   address rsp+0x68 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   [r8] == NULL || r8 is a valid argv
 #   [[rax]] == NULL || [rax] == NULL || [rax] is a valid envp
 #   rdi == NULL || writable: rdi
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rcx == NULL || (u16)[rcx] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rcx == NULL || (u16)[rcx] == 0x0
 #
-# 0x84135 posix_spawn(rbx+0xe0, "/bin/sh", r12, 0, rsp+0x60, environ)
+# 0x84165 posix_spawn(rbx+0xe0, "/bin/sh", r12, 0, rsp+0x60, environ)
 # constraints:
 #   address rsp+0x70 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   {"sh", "-c", rbp, NULL} is a valid argv
 #   rbx+0xe0 == NULL || writable: rbx+0xe0
-#   r12 == NULL || (s32)[r12+0x4] <= 0
+#   r12 == NULL || (s32)[r12+0x4] <= 0x0
 #
-# 0x8413c posix_spawn(rbx+0xe0, "/bin/sh", r12, 0, rsp+0x60, environ)
+# 0x8416c posix_spawn(rbx+0xe0, "/bin/sh", r12, 0, rsp+0x60, environ)
 # constraints:
 #   address rsp+0x70 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   rax == NULL || {"sh", rax, rbp, NULL} is a valid argv
 #   rbx+0xe0 == NULL || writable: rbx+0xe0
-#   r12 == NULL || (s32)[r12+0x4] <= 0
+#   r12 == NULL || (s32)[r12+0x4] <= 0x0
 #
-# 0x84143 posix_spawn(rbx+0xe0, "/bin/sh", r12, 0, rsp+0x60, environ)
+# 0x84173 posix_spawn(rbx+0xe0, "/bin/sh", r12, 0, rsp+0x60, environ)
 # constraints:
 #   address rsp+0x70 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   rcx == NULL || {rcx, rax, rbp, NULL} is a valid argv
 #   rbx+0xe0 == NULL || writable: rbx+0xe0
-#   r12 == NULL || (s32)[r12+0x4] <= 0
+#   r12 == NULL || (s32)[r12+0x4] <= 0x0
 #
-# 0x84146 posix_spawn(rbx+0xe0, "/bin/sh", rdx, 0, rsp+0x60, environ)
+# 0x84176 posix_spawn(rbx+0xe0, "/bin/sh", rdx, 0, rsp+0x60, environ)
 # constraints:
 #   address rsp+0x70 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   rcx == NULL || {rcx, rax, rbp, NULL} is a valid argv
 #   rbx+0xe0 == NULL || writable: rbx+0xe0
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
 #
-# 0x8414b posix_spawn(rbx+0xe0, "/bin/sh", rdx, 0, rsp+0x60, environ)
+# 0x8417b posix_spawn(rbx+0xe0, "/bin/sh", rdx, 0, rsp+0x60, environ)
 # constraints:
 #   address rsp+0x78 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   rcx == NULL || {rcx, rax, [rsp+0x70], NULL} is a valid argv
 #   rbx+0xe0 == NULL || writable: rbx+0xe0
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
 #
-# 0x84150 posix_spawn(rbx+0xe0, "/bin/sh", rdx, 0, rsp+0x60, environ)
+# 0x84180 posix_spawn(rbx+0xe0, "/bin/sh", rdx, 0, rsp+0x60, environ)
 # constraints:
 #   address rsp+0x78 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   rcx == NULL || {rcx, (u64)xmm1, [rsp+0x70], NULL} is a valid argv
 #   rbx+0xe0 == NULL || writable: rbx+0xe0
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
 #
-# 0x8415c posix_spawn(rbx+0xe0, "/bin/sh", rdx, 0, rsp+0x60, [rax])
+# 0x8418c posix_spawn(rbx+0xe0, "/bin/sh", rdx, 0, rsp+0x60, [rax])
 # constraints:
 #   address rsp+0x78 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   (u64)xmm0 == NULL || {(u64)xmm0, (u64)xmm1, [rsp+0x70], NULL} is a valid argv
 #   [[rax]] == NULL || [rax] == NULL || [rax] is a valid envp
 #   rbx+0xe0 == NULL || writable: rbx+0xe0
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
 #
-# 0x84162 posix_spawn(rbx+0xe0, "/bin/sh", rdx, rcx, rsp+0x60, [rax])
+# 0x84192 posix_spawn(rbx+0xe0, "/bin/sh", rdx, rcx, rsp+0x60, [rax])
 # constraints:
 #   address rsp+0x78 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   (u64)xmm0 == NULL || {(u64)xmm0, (u64)(xmm0 >> 64), [rsp+0x70], NULL} is a valid argv
 #   [[rax]] == NULL || [rax] == NULL || [rax] is a valid envp
 #   rbx+0xe0 == NULL || writable: rbx+0xe0
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rcx == NULL || (u16)[rcx] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rcx == NULL || (u16)[rcx] == 0x0
 #
-# 0x84169 posix_spawn(rdi, "/bin/sh", rdx, rcx, rsp+0x60, [rax])
+# 0x84199 posix_spawn(rdi, "/bin/sh", rdx, rcx, rsp+0x60, [rax])
 # constraints:
 #   address rsp+0x78 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   (u64)xmm0 == NULL || {(u64)xmm0, (u64)(xmm0 >> 64), [rsp+0x70], NULL} is a valid argv
 #   [[rax]] == NULL || [rax] == NULL || [rax] is a valid envp
 #   rdi == NULL || writable: rdi
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rcx == NULL || (u16)[rcx] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rcx == NULL || (u16)[rcx] == 0x0
 #
-# 0x84170 posix_spawn(rdi, "/bin/sh", rdx, rcx, r8, [rax])
+# 0x841a0 posix_spawn(rdi, "/bin/sh", rdx, rcx, r8, [rax])
 # constraints:
 #   address rsp+0x78 is writable
-#   rsp & 0xf == 0
+#   rsp & 0xf == 0x0
 #   [r8] == NULL || r8 is a valid argv
 #   [[rax]] == NULL || [rax] == NULL || [rax] is a valid envp
 #   rdi == NULL || writable: rdi
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
-#   rcx == NULL || (u16)[rcx] == NULL
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
+#   rcx == NULL || (u16)[rcx] == 0x0
 #
-# 0xe3afe execve("/bin/sh", r15, r12)
+# 0xe3b2e execve("/bin/sh", r15, r12)
 # constraints:
 #   [r15] == NULL || r15 == NULL || r15 is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3b01 execve("/bin/sh", r15, rdx)
+# 0xe3b31 execve("/bin/sh", r15, rdx)
 # constraints:
 #   [r15] == NULL || r15 == NULL || r15 is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
 #
-# 0xe3b04 execve("/bin/sh", rsi, rdx)
+# 0xe3b34 execve("/bin/sh", rsi, rdx)
 # constraints:
 #   [rsi] == NULL || rsi == NULL || rsi is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
 #
-# 0xe3cf3 execve("/bin/sh", r10, r12)
+# 0xe3d23 execve("/bin/sh", r10, r12)
 # constraints:
 #   address rbp-0x78 is writable
 #   [r10] == NULL || r10 == NULL || r10 is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3cf6 execve("/bin/sh", r10, rdx)
+# 0xe3d26 execve("/bin/sh", r10, rdx)
 # constraints:
 #   address rbp-0x78 is writable
 #   [r10] == NULL || r10 == NULL || r10 is a valid argv
 #   [rdx] == NULL || rdx == NULL || rdx is a valid envp
 #
-# 0xe3d62 execve("/bin/sh", rbp-0x50, r12)
+# 0xe3d92 execve("/bin/sh", rbp-0x50, r12)
 # constraints:
 #   address rbp-0x48 is writable
 #   r13 == NULL || {"/bin/sh", r13, NULL} is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3d69 execve("/bin/sh", rbp-0x50, r12)
+# 0xe3d99 execve("/bin/sh", rbp-0x50, r12)
 # constraints:
 #   address rbp-0x48 is writable
 #   rax == NULL || {rax, r13, NULL} is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3d70 execve("/bin/sh", rbp-0x50, r12)
+# 0xe3da0 execve("/bin/sh", rbp-0x50, r12)
 # constraints:
 #   address rbp-0x50 is writable
 #   rax == NULL || {rax, [rbp-0x48], NULL} is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3da7 execve("/bin/sh", rbp-0x50, r12)
+# 0xe3dd7 execve("/bin/sh", rbp-0x50, r12)
 # constraints:
 #   address rbp-0x50 is writable
 #   [rbp-0x68] == NULL || {"/bin/sh", [rbp-0x68], NULL} is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3db1 execve("/bin/sh", rbp-0x50, r12)
+# 0xe3de1 execve("/bin/sh", rbp-0x50, r12)
 # constraints:
 #   address rbp-0x50 is writable
 #   rax == NULL || {rax, [rbp-0x68], NULL} is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3db5 execve("/bin/sh", r10, r12)
+# 0xe3de5 execve("/bin/sh", r10, r12)
 # constraints:
 #   addresses r10+0x10, rbp-0x50 are writable
 #   [r10] == NULL || r10 == NULL || r10 is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0xe3dbd execve("/bin/sh", r10, r12)
+# 0xe3ded execve("/bin/sh", r10, r12)
 # constraints:
 #   addresses r10+0x10, rbp-0x48 are writable
 #   [r10] == NULL || r10 == NULL || r10 is a valid argv
 #   [r12] == NULL || r12 == NULL || r12 is a valid envp
 #
-# 0x1077ca posix_spawn(rsp+0x64, "/bin/sh", [rsp+0x38], 0, rsp+0x70, [rsp+0xf0])
+# 0x1075da posix_spawn(rsp+0x64, "/bin/sh", [rsp+0x38], 0, rsp+0x70, [rsp+0xf0])
 # constraints:
 #   [rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv
 #   [[rsp+0xf0]] == NULL || [rsp+0xf0] == NULL || [rsp+0xf0] is a valid envp
-#   [rsp+0x38] == NULL || (s32)[[rsp+0x38]+0x4] <= 0
+#   [rsp+0x38] == NULL || (s32)[[rsp+0x38]+0x4] <= 0x0
 #
-# 0x1077d2 posix_spawn(rsp+0x64, "/bin/sh", [rsp+0x38], 0, rsp+0x70, r9)
+# 0x1075e2 posix_spawn(rsp+0x64, "/bin/sh", [rsp+0x38], 0, rsp+0x70, r9)
 # constraints:
 #   [rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv
 #   [r9] == NULL || r9 == NULL || r9 is a valid envp
-#   [rsp+0x38] == NULL || (s32)[[rsp+0x38]+0x4] <= 0
+#   [rsp+0x38] == NULL || (s32)[[rsp+0x38]+0x4] <= 0x0
 #
-# 0x1077d7 posix_spawn(rsp+0x64, "/bin/sh", rdx, 0, rsp+0x70, r9)
+# 0x1075e7 posix_spawn(rsp+0x64, "/bin/sh", rdx, 0, rsp+0x70, r9)
 # constraints:
 #   [rsp+0x70] == NULL || {[rsp+0x70], [rsp+0x78], [rsp+0x80], [rsp+0x88], ...} is a valid argv
 #   [r9] == NULL || r9 == NULL || r9 is a valid envp
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
 #
-# 0x1077e1 posix_spawn(rdi, "/bin/sh", rdx, 0, r8, r9)
+# 0x1075f1 posix_spawn(rdi, "/bin/sh", rdx, 0, r8, r9)
 # constraints:
 #   [r8] == NULL || r8 is a valid argv
 #   [r9] == NULL || r9 == NULL || r9 is a valid envp
 #   rdi == NULL || writable: rdi
-#   rdx == NULL || (s32)[rdx+0x4] <= 0
+#   rdx == NULL || (s32)[rdx+0x4] <= 0x0
 
 ```
 
@@ -471,22 +484,45 @@ $ one_gadget /lib/x86_64-linux-gnu/libc.so.6 --level 1
 
 ##### i386
 ```bash
-$ one_gadget /lib32/libc.so.6
-# 0xc890b execve("/bin/sh", [ebp-0x2c], esi)
+$ one_gadget spec/data/libc-2.27-63b3d43ad45e1b0f601848c65b067f9e9b40528b.so
+# 0x3cbea execve("/bin/sh", esp+0x34, environ)
 # constraints:
-#   address ebp-0x20 is writable
-#   ebx is the GOT address of libc
-#   [[ebp-0x2c]] == NULL || [ebp-0x2c] == NULL || [ebp-0x2c] is a valid argv
-#   [esi] == NULL || esi == NULL || esi is a valid envp
+#   esi is the GOT address of libc
+#   [esp+0x34] == NULL || {[esp+0x34], [esp+0x38], [esp+0x3c], [esp+0x40], ...} is a valid argv
 #
-# 0x1421b3 execl("/bin/sh", eax)
+# 0x3cbec execve("/bin/sh", esp+0x38, environ)
 # constraints:
-#   ebp is the GOT address of libc
+#   esi is the GOT address of libc
+#   [esp+0x38] == NULL || {[esp+0x38], [esp+0x3c], [esp+0x40], [esp+0x44], ...} is a valid argv
+#
+# 0x3cbf0 execve("/bin/sh", esp+0x3c, environ)
+# constraints:
+#   esi is the GOT address of libc
+#   [esp+0x3c] == NULL || {[esp+0x3c], [esp+0x40], [esp+0x44], [esp+0x48], ...} is a valid argv
+#
+# 0x3cbf7 execve("/bin/sh", esp+0x40, environ)
+# constraints:
+#   esi is the GOT address of libc
+#   [esp+0x40] == NULL || {[esp+0x40], [esp+0x44], [esp+0x48], [esp+0x4c], ...} is a valid argv
+#
+# 0x6729f execl("/bin/sh", eax)
+# constraints:
+#   esi is the GOT address of libc
 #   eax == NULL
 #
-# 0x1421b4 execl("/bin/sh", [esp])
+# 0x672a0 execl("/bin/sh", [esp])
 # constraints:
-#   ebp is the GOT address of libc
+#   esi is the GOT address of libc
+#   [esp] == NULL
+#
+# 0x13573e execl("/bin/sh", eax)
+# constraints:
+#   ebx is the GOT address of libc
+#   eax == NULL
+#
+# 0x13573f execl("/bin/sh", [esp])
+# constraints:
+#   ebx is the GOT address of libc
 #   [esp] == NULL
 
 ```
@@ -526,8 +562,8 @@ $ one_gadget spec/data/arm-libc-2.39.so
 #   [[sp]] == NULL || [sp] is a valid argv
 #   [r3] == NULL || r3 == NULL || r3 is a valid envp
 #   r0 == NULL || writable: r0
-#   r2 == NULL || (s32)[r2+0x4] <= 0
-#   r8 == NULL || (u16)[r8] == NULL
+#   r2 == NULL || (s32)[r2+0x4] <= 0x0
+#   r8 == NULL || (u16)[r8] == 0x0
 #
 # 0x88a48 execve("/bin/sh", r4, r5)
 # constraints:
@@ -539,7 +575,8 @@ $ one_gadget spec/data/arm-libc-2.39.so
 #   [[sp+0x3c]] == NULL || [sp+0x3c] is a valid argv
 #   [r3] == NULL || r3 == NULL || r3 is a valid envp
 #   [sp+0x34] == NULL || writable: [sp+0x34]
-#   [sp+0x2c] == NULL || (s32)[[sp+0x2c]+0x4] <= 0
+#   [sp+0x2c] == NULL || (s32)[[sp+0x2c]+0x4] <= 0x0
+
 ```
 
 #### Combine with Script
@@ -547,7 +584,7 @@ Pass your exploit script as `one_gadget`'s arguments, it can
 try all gadgets one by one, so you don't need to try every possible gadgets manually.
 
 ```bash
-$ one_gadget ./spec/data/libc-2.19.so -s 'echo "offset ->"'
+$ one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so -s 'echo "offset ->"'
 ```
 
 ![--script](https://github.com/david942j/one_gadget/blob/master/examples/script.png?raw=true)
@@ -555,12 +592,12 @@ $ one_gadget ./spec/data/libc-2.19.so -s 'echo "offset ->"'
 ### In Ruby Scripts
 ```ruby
 require 'one_gadget'
-OneGadget.gadgets(file: '/lib/x86_64-linux-gnu/libc.so.6')
-#=> [932606, 932609, 932612]
+OneGadget.gadgets(file: 'spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so')
+#=> [932654, 932657, 932660]
 
 # or in shorter way
-one_gadget('/lib/x86_64-linux-gnu/libc.so.6', level: 1)
-#=> [335355, 335362, 335369, 335376, 335381, 335397, 335402, 335405, 335410, 540981, 540988, 540995, 540998, 541003, 541008, 541020, 541026, 541033, 541040, 932606, 932609, 932612, 933107, 933110, 933218, 933225, 933232, 933287, 933297, 933301, 933309, 1079242, 1079250, 1079255, 1079265]
+one_gadget('spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so', level: 1)
+#=> [335403, 335410, 335417, 335424, 335429, 335445, 335450, 335453, 335458, 541029, 541036, 541043, 541046, 541051, 541056, 541068, 541074, 541081, 541088, 932654, 932657, 932660, 933155, 933158, 933266, 933273, 933280, 933335, 933345, 933349, 933357, 1078746, 1078754, 1078759, 1078769]
 
 # from build id
 one_gadget('b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0')
@@ -574,8 +611,8 @@ import subprocess
 def one_gadget(filename):
   return [int(i) for i in subprocess.check_output(['one_gadget', '--raw', filename]).decode().split(' ')]
 
-one_gadget('/lib/x86_64-linux-gnu/libc.so.6')
-#=> [932606, 932609, 932612]
+one_gadget('spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so')
+#=> [932654, 932657, 932660]
 
 ```
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -53,7 +53,7 @@ SHELL_OUTPUT_OF(one_gadget)
 ```
 
 ```bash
-SHELL_OUTPUT_OF(one_gadget /lib/x86_64-linux-gnu/libc.so.6)
+SHELL_OUTPUT_OF(one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so)
 ```
 ![x86_64](https://github.com/david942j/one_gadget/blob/master/examples/x86_64.png?raw=true)
 
@@ -80,36 +80,49 @@ you will have at least 1/16 chance of success.
 Reorder gadgets according to the distance of given functions.
 
 ```bash
-SHELL_OUTPUT_OF(one_gadget /lib/x86_64-linux-gnu/libc.so.6 --near exit,mkdir)
+SHELL_OUTPUT_OF(one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so --near exit,mkdir)
 ```
 ![near](https://github.com/david942j/one_gadget/blob/master/examples/near.png?raw=true)
 
 Regular expression is acceptable.
 ```bash
-SHELL_OUTPUT_OF(one_gadget /lib/x86_64-linux-gnu/libc.so.6 --near 'write.*' --raw)
+SHELL_OUTPUT_OF(one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so --near 'write.*' --raw)
 ```
 
 Pass an ELF file as the argument, OneGadget will take all GOT functions for processing.
 ```bash
-SHELL_OUTPUT_OF(one_gadget /lib/x86_64-linux-gnu/libc.so.6 --near spec/data/test_near_file.elf --raw)
+SHELL_OUTPUT_OF(one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so --near spec/data/test_near_file.elf --raw)
 ```
 
-#### Show All Gadgets
+#### Show More Gadgets
 
-Sometimes `one_gadget` finds too many gadgets to show them in one screen,
-by default gadgets would be filtered automatically *according to the difficulty of constraints*.
+A libc holds far more gadgets than fit on a screen, and most of them ask more of you
+than a handful of others do. `--level` chooses how much of what was found to show.
 
-Use option `--level 1` to show all gadgets found instead of only those with higher probabilities.
+| Level | Shows | Use it when |
+| --- | --- | --- |
+| `0` (default) | the few gadgets whose constraints are easiest to arrange | always, first |
+| `1` | every gadget, one line per address, minus any that asks for everything an easier one asks for and more | none of the level-0 gadgets fit what you control |
+| `2` | everything found, including an address listed once per set of constraints it can be reached under | you want to see every way in, including the awkward ones |
+
+Level 1 drops a gadget when an easier one already asks for everything it does; level 0
+then scores what is left by how hard its constraints look and keeps only the best few;
+level 2 drops nothing. On the glibc 2.31 below that is 3, 35 and 97 entries -- the last
+over 96 addresses, since one of them is reachable two ways with different requirements.
+
+Level 2 also reads the libc you point at directly, where the levels below it answer
+from the pre-built gadget database when it knows the file's BuildID; the database only
+stores the trimmed set. Pass `-f` to search the file at every level.
 
 ```bash
-SHELL_OUTPUT_OF(one_gadget /lib/x86_64-linux-gnu/libc.so.6 --level 1)
+SHELL_OUTPUT_OF(one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so --level 1)
 ```
 
 #### Other Architectures
 
 ##### i386
 ```bash
-SHELL_OUTPUT_OF(one_gadget /lib32/libc.so.6)
+SHELL_OUTPUT_OF(one_gadget spec/data/libc-2.27-63b3d43ad45e1b0f601848c65b067f9e9b40528b.so)
 ```
 ![i386](https://github.com/david942j/one_gadget/blob/master/examples/i386.png?raw=true)
 
@@ -130,7 +143,7 @@ Pass your exploit script as `one_gadget`'s arguments, it can
 try all gadgets one by one, so you don't need to try every possible gadgets manually.
 
 ```bash
-$ one_gadget ./spec/data/libc-2.19.so -s 'echo "offset ->"'
+$ one_gadget spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so -s 'echo "offset ->"'
 ```
 
 ![--script](https://github.com/david942j/one_gadget/blob/master/examples/script.png?raw=true)
@@ -138,9 +151,9 @@ $ one_gadget ./spec/data/libc-2.19.so -s 'echo "offset ->"'
 ### In Ruby Scripts
 ```ruby
 require 'one_gadget'
-RUBY_OUTPUT_OF(OneGadget.gadgets(file: '/lib/x86_64-linux-gnu/libc.so.6'))
+RUBY_OUTPUT_OF(OneGadget.gadgets(file: 'spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so'))
 # or in shorter way
-RUBY_OUTPUT_OF(one_gadget('/lib/x86_64-linux-gnu/libc.so.6', level: 1))
+RUBY_OUTPUT_OF(one_gadget('spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so', level: 1))
 # from build id
 RUBY_OUTPUT_OF(one_gadget('b417c0ba7cc5cf06d1d1bed6652cedb9253c60d0'))
 ```
@@ -151,7 +164,7 @@ import subprocess
 def one_gadget(filename):
   return [int(i) for i in subprocess.check_output(['one_gadget', '--raw', filename]).decode().split(' ')]
 
-RUBY_OUTPUT_OF(one_gadget('/lib/x86_64-linux-gnu/libc.so.6'))
+RUBY_OUTPUT_OF(one_gadget('spec/data/libc-2.31-9fdb74e7b217d06c93172a8243f8547f947ee6d1.so'))
 ```
 
 ## Make OneGadget Better


### PR DESCRIPTION
The README described --level 1 as "show all gadgets found", which is not what it does and leaves level 2 undocumented. Level 1 is still filtered: it drops a gadget when an easier one already asks for everything it does. Level 2 is the one that drops nothing, lists an address once per set of constraints it can be reached under, and reads the libc directly rather than the pre-built database.

Give the three levels a table saying what each shows and when to reach for it.

Every example ran against /lib/x86_64-linux-gnu/libc.so.6, /lib32/libc.so.6, or a spec/data/libc-2.19.so that does not exist, so nobody but the author could regenerate the README or check what it claims. Point them at the libcs the repository ships, and the numbers quoted for the levels are what those commands print.