### PR TITLE
Match a libc to its sysroot by what the libc says it is

### DIFF
--- a/aletheia/lib/aletheia/transport.rb
+++ b/aletheia/lib/aletheia/transport.rb
@@ -58,7 +58,7 @@ module Aletheia
       def sysroot
         return @sysroot if defined?(@sysroot)
 
-        ver = File.basename(@target)[/(\d+\.\d+)/, 1]
+        ver = libc_version(@target)
         need = ver && @arch.version_strict? && ver != default_libc_version
         dir = need && File.join(ROOT, 'sysroots', "#{@arch.name}-#{ver}")
         @sysroot = dir && (stub_built?(dir) || build_sysroot(dir)) ? dir : nil
@@ -81,7 +81,19 @@ module Aletheia
       def default_libc_version
         libc = Dir[File.join(runtime_prefix, 'lib', '**', 'libc.so.6')].first ||
                Dir[File.join(runtime_prefix, 'lib', '*', 'libc.so.6')].first
-        libc && File.binread(libc)[/GLIBC (\d+\.\d+)/, 1]
+        libc && libc_version(libc)
+      end
+
+      # The glibc release a libc says it is. Every build states it the same way,
+      # whatever the vendor prefix, and it is the release -- not the name the file
+      # happens to carry -- that decides which sysroot can run it.
+      # @example
+      #   "GNU C Library (Ubuntu GLIBC 2.39-0ubuntu8.8) stable release version 2.39."
+      #   "GNU C Library (GNU libc) stable release version 2.26."
+      # @param [String] file
+      # @return [String?]
+      def libc_version(file)
+        File.binread(file)[/release version (\d+\.\d+)/, 1]
       end
 
       # Built, and not stale: a per-version stub is a cross-compile of park_stub.c

--- a/aletheia/spec/transport_spec.rb
+++ b/aletheia/spec/transport_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
+
+require 'fileutils'
+require 'tmpdir'
+
+require 'aletheia/arch/aarch64'
+require 'aletheia/transport'
+
+# A libc has to be matched to the sysroot that can run it, and the only thing
+# that says which release it is, is the libc.
+RSpec.describe Aletheia::Transport::Base do
+  let(:fixture) { File.expand_path('../spec/data/aarch64-libc-2.27.so', File.dirname(__dir__)) }
+
+  def transport(target)
+    described_class.new(Aletheia::Arch::AArch64, target)
+  end
+
+  it 'reads the glibc release out of the libc' do
+    expect(transport(fixture).send(:libc_version, fixture)).to eq '2.27'
+  end
+
+  # Distributions ship the file as plain libc.so.6, which names no version at
+  # all; reading the name instead would leave the release unknown and the libc
+  # running against whatever sysroot happened to be the default.
+  it 'reads it the same however the file is named' do
+    Dir.mktmpdir do |dir|
+      plain = File.join(dir, 'libc.so.6')
+      FileUtils.cp(fixture, plain)
+      expect(transport(plain).send(:libc_version, plain)).to eq '2.27'
+    end
+  end
+end


### PR DESCRIPTION
The release came from the file name, which every fixture happens to carry and a real libc.so.6 does not: the libc then ran against whatever sysroot was default and reached no execve, reported as gadget after gadget failing.