### PR TITLE
Ask for the GOT base only where a caller can put it

### DIFF
--- a/lib/one_gadget/fetchers/arm.rb
+++ b/lib/one_gadget/fetchers/arm.rb
@@ -95,8 +95,11 @@ module OneGadget
         res = super
         return res if res.nil? || @got_base_regs.empty?
 
-        @got_base_regs.each do |reg|
-          res[:constraints].unshift("#{reg} is the GOT address of libc")
+        gots = @got_base_regs.to_h { |reg| [reg, got_base_constraint(processor, reg)] }
+        return nil unless gots.values.all?
+
+        gots.each do |reg, got|
+          res[:constraints].unshift(got)
           res[:constraints].delete_if { |c| c.start_with?("writable: #{reg}") }
         end
         res

--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -500,6 +500,24 @@ module OneGadget
         str.match?(/\A\[*#{Regexp.escape(base)}(?:[+-]0x[0-9a-f]+)?\]*\z/)
       end
 
+      # The requirement that a value be libc's GOT base, when a register holds it.
+      # That is a precondition a caller can arrange and a reader can check: set
+      # the register before jumping. A candidate whose window loads the base out
+      # of memory instead names a location nobody sets up -- there is no register
+      # to point anywhere -- so it is refused rather than stated as a constraint
+      # nothing can meet.
+      # @param [OneGadget::Emulators::Processor] processor
+      # @param [String] holder Where the candidate found the GOT base.
+      # @return [String?] The constraint, or +nil+ if the candidate must be refused.
+      # @example
+      #   got_base_constraint(processor, 'ecx')        #=> "ecx is the GOT address of libc"
+      #   got_base_constraint(processor, '[ebp-0x2c]') #=> nil
+      def got_base_constraint(processor, holder)
+        return nil unless processor.registers.key?(holder)
+
+        "#{holder} is the GOT address of libc"
+      end
+
       def str_bin_sh?(_str); raise NotImplementedError
       end
 

--- a/lib/one_gadget/fetchers/i386.rb
+++ b/lib/one_gadget/fetchers/i386.rb
@@ -31,6 +31,7 @@ module OneGadget
         return nil unless str_bin_sh?(arg0.to_s)
 
         @base_reg = arg0.deref.obj.to_s # this should be esi or ebx..
+        got = got_base_constraint(processor, @base_reg) or return
         # now we can let parent invoke "global_var?"
         res = super
         return if res.nil?
@@ -41,7 +42,7 @@ module OneGadget
         # is dropped. Unlike arm, i386 doesn't seed this register to +$base+ before
         # emulating, so the emulator can't recognise it as mapped -- it is pruned
         # here once +@base_reg+ is known.
-        res[:constraints].unshift("#{@base_reg} is the GOT address of libc")
+        res[:constraints].unshift(got)
         res[:constraints].reject! { |c| c.match?(/\A(?:writable|readable): \[*#{Regexp.escape(@base_reg)}\b/) }
         res
       end

--- a/spec/fetchers/base_spec.rb
+++ b/spec/fetchers/base_spec.rb
@@ -2,13 +2,34 @@
 
 require 'one_gadget/emulators/amd64'
 require 'one_gadget/emulators/lambda'
+require 'one_gadget/emulators/i386'
 require 'one_gadget/fetchers/amd64'
+require 'one_gadget/fetchers/i386'
 
 describe OneGadget::Fetchers::Base do
   # Allocate without #initialize so no libc file / objdump is needed; these
   # tests only exercise the arch-independent private helpers of Base.
   let(:fetcher) { OneGadget::Fetchers::Amd64.allocate }
   let(:processor) { OneGadget::Emulators::Amd64.new }
+
+  # i386 PIC reaches its globals through whatever register holds the GOT base,
+  # so the gadget states which one -- and that is only a precondition a caller
+  # can arrange when it names a register.
+  describe '#got_base_constraint' do
+    let(:i386) { OneGadget::Fetchers::I386.allocate }
+    let(:i386_processor) { OneGadget::Emulators::I386.new }
+
+    it 'states the requirement for a register holding the base' do
+      expect(i386.send(:got_base_constraint, i386_processor, 'ecx'))
+        .to eq 'ecx is the GOT address of libc'
+    end
+
+    # A window that loads the base out of a stack slot names a place the caller
+    # never sets up, so there is nothing to ask of them and the candidate goes.
+    it 'refuses a base the candidate reads out of memory' do
+      expect(i386.send(:got_base_constraint, i386_processor, '[ebp-0x2c]')).to be_nil
+    end
+  end
 
   describe '#check_stack_argv' do
     # The argv pointer lives on the stack and every argv[i] happens to be a


### PR DESCRIPTION
The constraint names whatever held libc's GOT base, which for a window that loads it from a stack slot is a location no caller sets up and nothing can check. Refuse such a candidate instead of stating it.