### PR TITLE
Run the two x86 instructions that stop a candidate for nothing

### DIFF
--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -69,6 +69,8 @@ module OneGadget
           Instruction.new('add', 2),
           Instruction.new('and', 2),
           Instruction.new('call', 1),
+          Instruction.new('endbr32', -1),
+          Instruction.new('endbr64', -1),
           Instruction.new('jmp', 1),
           Instruction.new('lea', 2),
           Instruction.new('mov', 2),
@@ -76,6 +78,7 @@ module OneGadget
           Instruction.new('nop', -1),
           Instruction.new('push', 1),
           Instruction.new('sub', 2),
+          Instruction.new('xchg', 2),
           Instruction.new('xor', 2),
           Instruction.new('movq', 2),
           Instruction.new('movaps', 2),
@@ -85,6 +88,11 @@ module OneGadget
       end
 
       private
+
+      # Whether a whole register's worth of value is what this operand names.
+      def swappable?(operand)
+        register?(operand) && !OneGadget::ABI::NARROW_VIEWS.fetch(arch_name, {}).key?(operand)
+      end
 
       def branch_mnem?(mnem)
         mnem == 'jmp' || JCC.key?(mnem) || %w[jcxz jecxz jrcxz].include?(mnem)
@@ -297,6 +305,27 @@ module OneGadget
 
       # yap, nop
       def inst_nop(*); end
+
+      # A marker for the branch predictor: it says a jump may land here and leaves
+      # every value alone.
+      def inst_endbr64(*); end
+      alias inst_endbr32 inst_endbr64
+
+      # Swap what two registers hold. Two forms are not that, and stay refused: a
+      # memory operand is an exchange with memory (and an atomic one), and a
+      # narrower view names part of a register, which swapping whole values cannot
+      # express. Naming one place twice is nothing at all, whatever it names --
+      # that is the multi-byte nop a compiler pads with.
+      # @example
+      #   xchg ebx,edi  -- a swap
+      #   xchg ax,ax    -- padding
+      def inst_xchg(dst, src)
+        return if dst == src
+        raise Error::UnsupportedInstructionArgumentError, "xchg #{dst},#{src}" unless
+          swappable?(dst) && swappable?(src)
+
+        registers[dst], registers[src] = registers[src], registers[dst]
+      end
 
       # TODO: handle some registers would be fucked after call
       def inst_call(addr)

--- a/spec/emulators/i386_spec.rb
+++ b/spec/emulators/i386_spec.rb
@@ -7,6 +7,39 @@ describe OneGadget::Emulators::I386 do
     @processor = described_class.new
   end
 
+  # A compiler pads with `xchg ax,ax` and swaps registers with the real thing;
+  # both used to stop a candidate outright.
+  describe 'xchg' do
+    it 'swaps what the two registers hold' do
+      ebx = @processor.registers['ebx']
+      edi = @processor.registers['edi']
+      expect(@processor.process("  3fa77:\txchg   ebx,edi\n")).to be true
+      expect(@processor.registers['ebx'].to_s).to eq edi.to_s
+      expect(@processor.registers['edi'].to_s).to eq ebx.to_s
+    end
+
+    it 'does nothing when it names one register twice' do
+      before = @processor.registers['eax'].to_s
+      expect(@processor.process("  ed21e:\txchg   ax,ax\n")).to be true
+      expect(@processor.registers['eax'].to_s).to eq before
+    end
+
+    # An exchange with memory is a different instruction from a register swap --
+    # and an atomic one -- so it stops the candidate rather than being guessed at.
+    it 'refuses an exchange with memory' do
+      expect(@processor.process("  7fdcd:\txchg   DWORD PTR [esi+0x1a00],edx\n")).to be false
+    end
+  end
+
+  # The marker says a branch may land here; it touches nothing.
+  describe 'endbr' do
+    it 'runs on without changing anything' do
+      before = @processor.registers.transform_values(&:to_s)
+      expect(@processor.process("  ed2e0:\tendbr32\n")).to be true
+      expect(@processor.registers.transform_values(&:to_s)).to eq before
+    end
+  end
+
   describe 'process' do
     it 'libc-2.23' do
       gadget = <<-EOS


### PR DESCRIPTION
A branch-target marker touches no value, and a register exchange is a swap of two tracked ones -- between them they truncated more x86 candidates than any real gap. An exchange with memory, and one naming half a register, stay refused.