### PR TITLE
Recognise an architecture by what the ELF says, not what a library ca…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ test corpus reports has been run under a debugger and seen to spawn a shell.
   (#325), and a candidate whose path cannot hold is rejected (#359, #360).
 - Searching a libc got roughly five times faster: the test corpus at level 0
   went from 42.5s to 8.6s (#388, #389, #390, #393, #394, #395, #396).
-- Requires Ruby >= 3.3 (#293).
+- Requires Ruby >= 3.3 (#293) and elftools >= 2.0.0.
 
 ### Fixed
 
@@ -74,6 +74,10 @@ test corpus reports has been run under a debugger and seen to spawn a shell.
   call, and could invent gadgets by falling through a window boundary (#391,
   #392).
 - The "not glibc" check did not fire for aarch64 files (#311).
+- An architecture is recognised by the machine type its ELF header states, not
+  by the name the reader library prints for it -- the latter is that library's
+  wording and changed in elftools 2.0.0, which left every aarch64 and amd64 file
+  reading as an unknown architecture.
 
 ## v1.10.0 - 2024-10-04
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,17 @@ PATH
   remote: .
   specs:
     one_gadget (1.10.0)
-      elftools (>= 1.0.2, < 1.4.0)
+      elftools (>= 2.0.0, < 3.0.0)
       logger
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    bindata (2.5.1)
+    bindata (3.0.0)
     diff-lcs (1.6.2)
-    elftools (1.3.1)
-      bindata (~> 2)
+    elftools (2.0.0)
+      bindata (>= 2, < 4)
     json (2.21.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)

--- a/lib/one_gadget/helper.rb
+++ b/lib/one_gadget/helper.rb
@@ -192,11 +192,22 @@ module OneGadget
     end
 
     # Fetch the ELF architecture of +file+.
+    # What this tool calls each architecture it can search. Keyed by the
+    # header's own value, which is fixed by the ELF ABI, rather than by the name a
+    # reader library prints for it -- that is the library's wording and does
+    # change, as elftools 2.0.0 renamed "AArch64" to "ARM 64-bit architecture".
+    MACHINES = {
+      ELFTools::Constants::EM::EM_386 => :i386,
+      ELFTools::Constants::EM::EM_ARM => :arm,
+      ELFTools::Constants::EM::EM_X86_64 => :amd64,
+      ELFTools::Constants::EM::EM_AARCH64 => :aarch64
+    }.freeze
+
     # @param [String] file The target ELF filename.
     # @return [Symbol]
-    #   One of +:amd64+, +:i386+, +:arm+, +:aarch64+, or +:mips+ for a recognized
-    #   architecture, +:unknown+ for a valid ELF with an unsupported machine type,
-    #   or +:invalid+ when +file+ does not exist or is not a valid ELF.
+    #   One of +:amd64+, +:i386+, +:arm+ or +:aarch64+, +:unknown+ for a valid ELF
+    #   this tool cannot search, or +:invalid+ when +file+ does not exist or is
+    #   not a valid ELF.
     # @example
     #   Helper.architecture('/bin/cat')
     #   #=> :amd64
@@ -204,14 +215,7 @@ module OneGadget
       return :invalid unless File.exist?(file)
 
       f = File.open(file) # rubocop:disable Style/FileOpen
-      str = ELFTools::ELFFile.new(f).machine
-      {
-        'Advanced Micro Devices X86-64' => :amd64,
-        'Intel 80386' => :i386,
-        'ARM' => :arm,
-        'AArch64' => :aarch64,
-        'MIPS R3000' => :mips
-      }[str] || :unknown
+      MACHINES[ELFTools::ELFFile.new(f).header.e_machine.to_i] || :unknown
     rescue ELFTools::ELFError # not a valid ELF
       :invalid
     ensure

--- a/one_gadget.gemspec
+++ b/one_gadget.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.3'
 
-  s.add_dependency 'elftools', '>= 1.0.2', '< 1.4.0'
+  s.add_dependency 'elftools', '>= 2.0.0', '< 3.0.0'
   s.add_dependency 'logger'
 
   s.add_development_dependency 'rake', '~> 13.0'

--- a/tasks/builds/generate.rake
+++ b/tasks/builds/generate.rake
@@ -68,13 +68,17 @@ namespace :builds do
   # @param [String] filename Path of the libc to read.
   # @param [String] source Where that libc came from, recorded as the build file's first line.
   def libc_info(filename, source = filename)
+    # The architectures a gadget can be searched for; the ELF reader knows plenty
+    # this tool cannot emulate.
+    machine = OneGadget::Helper.architecture(filename)
+    return nil unless %i[aarch64 amd64 arm i386].include?(machine)
+
     file = File.open(filename) # rubocop:disable Style/FileOpen
     libc = ELFTools::ELFFile.new(file)
     build_id = libc.build_id
     arch = libc.machine
-    return nil unless ['Advanced Micro Devices X86-64', 'Intel 80386', 'AArch64', 'ARM'].include?(arch)
     # let's skip amd64 with 32bit, i.e. x32
-    return nil if arch.start_with?('Advanced') && libc.elf_class == 32
+    return nil if machine == :amd64 && libc.elf_class == 32
 
     str = file.read
     st = str.index('GNU C Library')


### PR DESCRIPTION
…lls it

elftools 2.0.0 rewords its machine names -- AArch64 became "ARM 64-bit architecture" -- and matching on that prose left every aarch64 and amd64 file reading as unknown. The header's machine number does not move.