### PR TITLE
Move the architecture-neutral instruction helpers into Processor

### DIFF
--- a/docs/adding-an-architecture.md
+++ b/docs/adding-an-architecture.md
@@ -136,7 +136,12 @@ Optional hooks (sensible defaults in `Base`):
 **Inherited from `Processor` — don't reimplement.** The frame-pointer/stack model
 (`get_corresponding_stack`, `setup_frame_pointer`, `eval_dict`, `reg_based_stack`),
 the writable-constraint logic (`add_writable`/`needs_writable?`, which skip `sp`,
-`pc`, and `libc_base` for free), the libc-base marker (`libc_base`,
+`pc`, and `libc_base` for free), the value-computing helpers an `inst_*` handler is
+built from (`arith` for add/sub — including the refusal to let `sp` go symbolic —
+`data_op` for a bitwise or shift operator, `complement`, `shorthand`, `value_of`,
+`width_mask`), the store tracker (`track_write`, which writes each word into the
+stack the address resolves to and requires anything but a pure `sp` store
+writable), the libc-base marker (`libc_base`,
 `mapped_pointer?`), and the table of non-terminal libc calls the emulator accepts
 without executing (`SafeCalls::COMMON`, applied by `dispatch_safe_call` — the
 `posix_spawn` setup helpers, `sigprocmask`, `__sigaction`, …) are all

--- a/lib/one_gadget/emulators/arm_family.rb
+++ b/lib/one_gadget/emulators/arm_family.rb
@@ -69,6 +69,22 @@ module OneGadget
         OneGadget::Helper.hex(m[1] == 'lsl' ? value << Integer(m[2]) : value >> Integer(m[2]))
       end
 
+      # +op2+ with the modifier this family may spell on it folded in: a constant
+      # shift, or (aarch64) a sign-extension of its low half, which is taken
+      # whole. A +nil+ modifier is the bare operand. Yields, rather than
+      # returning, for a modifier this family does not model, so an unmodelled one
+      # aborts instead of being silently dropped.
+      # @param [String] op2 The operand the modifier applies to.
+      # @param [String, nil] mode The modifier, as written.
+      # @example (aarch64) +add x0, x1, w2, sxtw+ -- +mode+ is +"sxtw"+
+      # @example (arm) +add r0, r1, r2, lsl 3+ -- +mode+ is +"lsl 3"+
+      # @return [String] The operand {Processor#arith} then reads.
+      def modified_operand(op2, mode)
+        return op2 if mode.nil? || mode == 'sxtw'
+
+        shifted_operand(value_str(value_of(op2)), mode) || yield
+      end
+
       # +add+/+sub+, shared by both families. Each allows the 2-operand shorthand,
       # and each may carry a modifier on +op2+ -- a shift, or (aarch64) a
       # sign-extension of its low half.
@@ -77,94 +93,22 @@ module OneGadget
       # @param [String, nil] op2 The value to add, or nil in the 2-operand form.
       # @param [String, nil] mode A modifier applied to +op2+ (see {#modified_operand}).
       # @return [void]
-      def inst_add(dst, src, op2 = nil, mode = nil) = arith(:+, dst, src, op2, mode)
+      def inst_add(dst, src, op2 = nil, mode = nil)
+        arith(:+, dst, src, modified_operand(op2, mode) { raise_unsupported(:+, dst, src, op2, mode) })
+      end
 
       # +sub dst, src, op2+. See {#inst_add} for the operands.
       # @return [void]
-      def inst_sub(dst, src, op2 = nil, mode = nil) = arith(:-, dst, src, op2, mode)
-
-      # Add or subtract, and store the result.
-      #
-      # A sum of two values neither of which is known folds into no base+offset,
-      # so it is named as the operation it is -- a candidate deriving a pointer
-      # that way still says what the caller has to arrange. That is the only
-      # fallback: an offset from a known base stays a base+offset, which the rest
-      # of the emulator can resolve against tracked memory.
-      # @param [Symbol] op +:++ or +:-+.
-      # @return [void]
-      # @raise [OneGadget::Error::UnsupportedInstructionArgumentError]
-      #   When the modifier, or the result, is not one this emulator can name.
-      def arith(op, dst, src, op2, mode)
-        check_register!(dst)
-        src, op2 = shorthand(dst, src, op2)
-        lhs = value_of(src)
-        rhs = modified_operand(value_of(op2), mode) { raise_unsupported(op, dst, src, op2, mode) }
-
-        result = offset_result(op, lhs, rhs)
-        # The stack pointer has to stay an offset from itself: every tracked
-        # stack slot is keyed on it, and a candidate that reads one back after
-        # allocating a variable-size frame would be answered from the wrong
-        # place. Such a frame also puts the array a gadget builds at an address
-        # only a register the caller supplies decides, which no constraint this
-        # emulator emits states.
-        result ||= operation_result(op, lhs, rhs) unless dst == sp
-        raise_unsupported(op, dst, src, op2) if result.nil?
-
-        registers[dst] = result
-      end
-
-      # +lhs op rhs+ when the result is an offset from +lhs+'s base, which
-      # {Lambda} expresses directly. +nil+ when it is not, leaving the caller to
-      # name the operation instead.
-      # @return [Lambda, Integer, nil]
-      def offset_result(op, lhs, rhs)
-        return lhs.send(op, rhs) if rhs.is_a?(Integer)
-        # Adding a known offset to an unknown value is the same value shifted;
-        # subtracting from one is not, so only addition commutes here.
-        return rhs + lhs if op == :+ && lhs.is_a?(Integer)
-
-        nil
-      end
-
-      # +value+ with an operand modifier applied. +nil+ +mode+ is the bare
-      # operand. Yields, rather than returning, for a modifier this emulator does
-      # not model, so an unmodelled one aborts instead of being silently dropped.
-      # @example (aarch64) +add x0, x1, w2, sxtw+ -- +mode+ is +"sxtw"+
-      # @example (arm) +add r0, r1, r2, lsl 3+ -- +mode+ is +"lsl 3"+
-      # @return [Lambda, Integer]
-      def modified_operand(value, mode)
-        return value if mode.nil? || mode == 'sxtw' # a sign-extension we take whole
-
-        shifted = shifted_operand(value_str(value), mode)
-        return yield if shifted.nil?
-
-        Integer(shifted)
-      end
-
-      # Apply a data-processing instruction and store its result. Both families
-      # allow the 2-operand shorthand, so +src+ may be the only operand given.
-      # @param [String] name The mnemonic, and the {DATA_OPS} key naming its operator.
-      # @param [String] dst The destination register.
-      # @param [String] src The left operand, or the only one given (see {#shorthand}).
-      # @param [String, nil] op2 The right operand, or nil in the 2-operand form.
-      # @return [void]
-      # @raise [OneGadget::Error::UnsupportedInstructionArgumentError]
-      #   When the result is nothing this emulator can name.
-      def data_op(name, dst, src, op2)
-        check_register!(dst)
-        src, op2 = shorthand(dst, src, op2)
-        result = operation_result(DATA_OPS.fetch(name), value_of(src), value_of(op2))
-        raise_unsupported(name, dst, src, op2) if result.nil?
-
-        # A shift can push bits past the register width, which the arbitrary-
-        # precision fold above would otherwise keep.
-        registers[dst] = result.is_a?(Integer) ? result & width_mask : result
+      def inst_sub(dst, src, op2 = nil, mode = nil)
+        arith(:-, dst, src, modified_operand(op2, mode) { raise_unsupported(:-, dst, src, op2, mode) })
       end
 
       # Each {DATA_OPS} mnemonic handled the one way, since they differ only in the
-      # operator applied (see {#data_op} for the operands).
+      # operator applied (see {Processor#data_op} for the operands).
       %w[and orr eor lsl lsr].each do |name|
-        define_method(:"inst_#{name}") { |dst, src, op2 = nil| data_op(name, dst, src, op2) }
+        define_method(:"inst_#{name}") do |dst, src, op2 = nil|
+          data_op(DATA_OPS.fetch(name), dst, src, op2, name:)
+        end
       end
 
       # +bic dst, src, op2+ clears the bits +op2+ sets, which is +and+ against its
@@ -176,7 +120,8 @@ module OneGadget
       # @return [void]
       def inst_bic(dst, src, op2 = nil)
         src, op2 = shorthand(dst, src, op2)
-        data_op('and', dst, src, OneGadget::Helper.hex(complement('bic', op2, dst, src, op2)))
+        data_op(DATA_OPS.fetch('and'), dst, src,
+                OneGadget::Helper.hex(complement('bic', op2, dst, src, op2)), name: 'and')
       end
 
       # +mvn dst, op2+ is that complement on its own.
@@ -188,51 +133,6 @@ module OneGadget
 
         registers[dst] = complement('mvn', op2, dst, op2)
       end
-
-      # +op2+ with every bit flipped. Only a concrete value has a complement this
-      # emulator can name; a symbolic one aborts rather than being recorded as a
-      # mask it isn't.
-      # @param [String] name The mnemonic to report an abort against.
-      # @param [String] op2 The operand to complement.
-      # @param [Array<String>] reported The operands to name in that abort.
-      # @return [Integer] +op2+ complemented, within the register width.
-      def complement(name, op2, *reported)
-        value = value_of(op2)
-        raise_unsupported(name, *reported) unless value.is_a?(Integer)
-
-        ~value & width_mask
-      end
-
-      # Every bit of a register, for masking a result back to its width.
-      # @return [Integer]
-      def width_mask = (1 << self.class.bits) - 1
-
-      # The value of an operand. {Arm} overrides it for +pc+, whose value depends
-      # on the address of the instruction reading it.
-      # @param [String] arg The operand, as written.
-      # @return [OneGadget::Emulators::Lambda, Integer] Its current value.
-      def value_of(arg) = arg_to_lambda(arg)
-
-      # Expand a 2-operand data-processing form into its (src, op2) operands:
-      # +add dst, op2+ is shorthand for +add dst, dst, op2+, while an explicit
-      # 3-operand form is passed through unchanged.
-      # @param [String] dst The destination register, which the 2-operand form
-      #   also reads as its left operand.
-      # @param [String] src The left operand, or the right one in the 2-operand form.
-      # @param [String, nil] op2 The right operand, or nil in the 2-operand form.
-      # @return [(String, String)] The left and right operands.
-      # @example
-      #   shorthand('r0', 'r4', nil) # 2-operand: add r0, r4
-      #   #=> ['r0', 'r4']
-      #   shorthand('r0', 'r4', '8') # 3-operand: add r0, r4, 8
-      #   #=> ['r4', '8']
-      def shorthand(dst, src, op2)
-        op2.nil? ? [dst, src] : [src, op2]
-      end
-
-      # An instruction with no effect this emulator models anything of.
-      # @return [void]
-      def inst_nop(*); end
 
       # A memory barrier orders accesses without changing any value, so a path
       # crossing one carries on unchanged. The operand naming its scope (+dmb ish+)
@@ -247,21 +147,6 @@ module OneGadget
         return reach_terminal_call(addr) if terminal_call?(addr)
 
         dispatch_safe_call(addr)
-      end
-
-      # Track a store: write +values+ (one per word from +dst_l+) into the stack
-      # {#resolve_address} resolves +dst_l+ to, and require +dst_l+
-      # writable -- unless it is a pure +sp+ store. +sp+ is invariantly the
-      # writable stack; the frame pointer only conventionally is, so a store
-      # through it stays a real precondition (like amd64's +writable: rbp+imm+).
-      # Shared by +str+ (one value) and +stp+ (two).
-      # @param [OneGadget::Emulators::Lambda] dst_l The destination, zero-deref.
-      # @param [Array<OneGadget::Emulators::Lambda, Integer>] values One per word.
-      # @return [void]
-      def track_write(dst_l, *values)
-        stack, offset = resolve_address(dst_l)
-        values.each_with_index { |v, i| stack[offset + size_t * i] = v } if stack
-        add_writable(dst_l) unless stack.equal?(sp_based_stack)
       end
 
       # A byte load. The address is read like any other, so what the caller has to
@@ -280,20 +165,6 @@ module OneGadget
       # @param [Boolean] negate +false+ for +cbz+, +true+ for +cbnz+.
       def handle_cbz(ops, negate:)
         branch_on_zero(ops[1].to_i(16), ops[0], negate:)
-      end
-
-      # Replace register tokens that currently hold a concrete integer with that
-      # integer, so a register-indexed memory operand becomes an offset one the
-      # Lambda parser handles.
-      # @example
-      #   # with the index register currently holding 0xd8
-      #   resolve_int_regs('[r8, r2]')  #=> '[r8, 0xd8]'
-      #   resolve_int_regs('[x8, x2]')  #=> '[x8, 0xd8]'
-      def resolve_int_regs(str)
-        str.gsub(/[a-z]+\d*/) do |tok|
-          v = registers[tok] if register?(tok)
-          v.is_a?(Integer) ? OneGadget::Helper.hex(v) : tok
-        end
       end
     end
   end

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -697,6 +697,146 @@ module OneGadget
         OneGadget::Emulators::Lambda.operation(lhs, op.to_s, rhs)
       end
 
+      # Add or subtract, and store the result.
+      #
+      # A sum of two values neither of which is known folds into no base+offset,
+      # so it is named as the operation it is -- a candidate deriving a pointer
+      # that way still says what the caller has to arrange. That is the only
+      # fallback: an offset from a known base stays a base+offset, which the rest
+      # of the emulator can resolve against tracked memory.
+      # @param [Symbol] op +:++ or +:-+.
+      # @param [String] dst The destination register.
+      # @param [String] src The value added to, or the only operand given.
+      # @param [String, nil] op2 The value to add, or nil in the 2-operand form.
+      # @return [void]
+      # @raise [OneGadget::Error::UnsupportedInstructionArgumentError]
+      #   When the result is not one this emulator can name.
+      def arith(op, dst, src, op2)
+        check_register!(dst)
+        src, op2 = shorthand(dst, src, op2)
+        lhs = value_of(src)
+        rhs = value_of(op2)
+
+        result = offset_result(op, lhs, rhs)
+        # The stack pointer has to stay an offset from itself: every tracked
+        # stack slot is keyed on it, and a candidate that reads one back after
+        # allocating a variable-size frame would be answered from the wrong
+        # place. Such a frame also puts the array a gadget builds at an address
+        # only a register the caller supplies decides, which no constraint this
+        # emulator emits states.
+        result ||= operation_result(op, lhs, rhs) unless dst == sp
+        raise_unsupported(op, dst, src, op2) if result.nil?
+
+        registers[dst] = result
+      end
+
+      # +lhs op rhs+ when the result is an offset from +lhs+'s base, which
+      # {Lambda} expresses directly. +nil+ when it is not, leaving the caller to
+      # name the operation instead.
+      # @return [Lambda, Integer, nil]
+      def offset_result(op, lhs, rhs)
+        return lhs.send(op, rhs) if rhs.is_a?(Integer)
+        # Adding a known offset to an unknown value is the same value shifted;
+        # subtracting from one is not, so only addition commutes here.
+        return rhs + lhs if op == :+ && lhs.is_a?(Integer)
+
+        nil
+      end
+
+      # Apply a data-processing instruction and store its result. An arch that
+      # allows the 2-operand shorthand may pass +src+ as the only operand.
+      # @param [Symbol] op A Ruby operator that doubles as how the operation renders.
+      # @param [String] dst The destination register.
+      # @param [String] src The left operand, or the only one given (see {#shorthand}).
+      # @param [String, nil] op2 The right operand, or nil in the 2-operand form.
+      # @param [String] name The mnemonic, named in an abort.
+      # @return [void]
+      # @raise [OneGadget::Error::UnsupportedInstructionArgumentError]
+      #   When the result is nothing this emulator can name.
+      def data_op(op, dst, src, op2, name:)
+        check_register!(dst)
+        src, op2 = shorthand(dst, src, op2)
+        result = operation_result(op, value_of(src), value_of(op2))
+        raise_unsupported(name, dst, src, op2) if result.nil?
+
+        # A shift can push bits past the register width, which the arbitrary-
+        # precision fold above would otherwise keep.
+        registers[dst] = result.is_a?(Integer) ? result & width_mask : result
+      end
+
+      # +op2+ with every bit flipped. Only a concrete value has a complement this
+      # emulator can name; a symbolic one aborts rather than being recorded as a
+      # mask it isn't.
+      # @param [String] name The mnemonic to report an abort against.
+      # @param [String] op2 The operand to complement.
+      # @param [Array<String>] reported The operands to name in that abort.
+      # @return [Integer] +op2+ complemented, within the register width.
+      def complement(name, op2, *reported)
+        value = value_of(op2)
+        raise_unsupported(name, *reported) unless value.is_a?(Integer)
+
+        ~value & width_mask
+      end
+
+      # Every bit of a register, for masking a result back to its width.
+      # @return [Integer]
+      def width_mask = (1 << self.class.bits) - 1
+
+      # The value of an operand. {Arm} overrides it for +pc+, whose value depends
+      # on the address of the instruction reading it.
+      # @param [String] arg The operand, as written.
+      # @return [OneGadget::Emulators::Lambda, Integer] Its current value.
+      def value_of(arg) = arg_to_lambda(arg)
+
+      # Expand a 2-operand data-processing form into its (src, op2) operands:
+      # +add dst, op2+ is shorthand for +add dst, dst, op2+, while an explicit
+      # 3-operand form is passed through unchanged.
+      # @param [String] dst The destination register, which the 2-operand form
+      #   also reads as its left operand.
+      # @param [String] src The left operand, or the right one in the 2-operand form.
+      # @param [String, nil] op2 The right operand, or nil in the 2-operand form.
+      # @return [(String, String)] The left and right operands.
+      # @example
+      #   shorthand('r0', 'r4', nil) # 2-operand: add r0, r4
+      #   #=> ['r0', 'r4']
+      #   shorthand('r0', 'r4', '8') # 3-operand: add r0, r4, 8
+      #   #=> ['r4', '8']
+      def shorthand(dst, src, op2)
+        op2.nil? ? [dst, src] : [src, op2]
+      end
+
+      # An instruction with no effect this emulator models anything of.
+      # @return [void]
+      def inst_nop(*); end
+
+      # Track a store: write +values+ (one per word from +dst_l+) into the stack
+      # {#resolve_address} resolves +dst_l+ to, and require +dst_l+
+      # writable -- unless it is a pure +sp+ store. +sp+ is invariantly the
+      # writable stack; the frame pointer only conventionally is, so a store
+      # through it stays a real precondition (like amd64's +writable: rbp+imm+).
+      # @param [OneGadget::Emulators::Lambda] dst_l The destination, zero-deref.
+      # @param [Array<OneGadget::Emulators::Lambda, Integer>] values One per word.
+      # @return [void]
+      def track_write(dst_l, *values)
+        stack, offset = resolve_address(dst_l)
+        values.each_with_index { |v, i| stack[offset + size_t * i] = v } if stack
+        add_writable(dst_l) unless stack.equal?(sp_based_stack)
+      end
+
+      # Replace register tokens that currently hold a concrete integer with that
+      # integer, so a register-indexed memory operand becomes an offset one the
+      # Lambda parser handles.
+      # @example
+      #   # with the index register currently holding 0xd8
+      #   resolve_int_regs('[r8, r2]')  #=> '[r8, 0xd8]'
+      #   resolve_int_regs('[x8, x2]')  #=> '[x8, 0xd8]'
+      def resolve_int_regs(str)
+        str.gsub(/[a-z]+\d*/) do |tok|
+          v = registers[tok] if register?(tok)
+          v.is_a?(Integer) ? OneGadget::Helper.hex(v) : tok
+        end
+      end
+
       def raise_unsupported(inst, *args)
         raise OneGadget::Error::UnsupportedInstructionArgumentError, "#{inst} #{args.join(', ')}"
       end

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -303,9 +303,6 @@ module OneGadget
         registers[dst] -= src
       end
 
-      # yap, nop
-      def inst_nop(*); end
-
       # A marker for the branch predictor: it says a jump may land here and leaves
       # every value alone.
       def inst_endbr64(*); end


### PR DESCRIPTION
arith, data_op, complement, shorthand, value_of, width_mask, inst_nop, track_write and resolve_int_regs describe no ISA in particular, but sat in ArmFamily, so a third family would have had to copy them. Lift them into Processor, where the base already documents them as the parts an arch inherits unchanged.

ArmFamily keeps what is genuinely ARM's: the condition codes, the compare handling, and the modifier an operand may carry, which is now folded into that operand before arith reads it rather than through a hook in the base.

The corpus is byte-identical at levels 0/1/2 across every fixture.