### PR TITLE
Let a mnemonic carry a dot

### DIFF
--- a/docs/adding-an-architecture.md
+++ b/docs/adding-an-architecture.md
@@ -143,7 +143,7 @@ Optional hooks (sensible defaults in `Base`):
 | `operands(cmd)` | split an instruction into its operand strings |
 | `branch_mnem?(mnem)` | is `mnem` a branch this emulator handles? |
 | `handle_branch(mnem, cmd)` | turn a branch into a pending decision (via the `branch_on_*` helpers below) |
-| `inst_<name>(...)` | one handler per supported instruction |
+| `inst_<name>(...)` | one handler per supported instruction; a mnemonic spelled with a dot takes its name from `Instruction.handler_name` (`sext.w` -> `inst_sext_w`) |
 
 **Inherited from `Processor` — don't reimplement.** The frame-pointer/stack model
 (`get_corresponding_stack`, `setup_frame_pointer`, `eval_dict`, `reg_based_stack`)

--- a/lib/one_gadget/emulators/aarch64.rb
+++ b/lib/one_gadget/emulators/aarch64.rb
@@ -27,8 +27,7 @@ module OneGadget
         return handle_branch(mnem, cmd) != :fail if branch_mnem?(mnem)
 
         inst, args = parse(cmd)
-        sym = :"inst_#{inst.inst}"
-        __send__(sym, *args) != :fail
+        __send__(inst.handler, *args) != :fail
       end
 
       # Supported instruction set.

--- a/lib/one_gadget/emulators/arm.rb
+++ b/lib/one_gadget/emulators/arm.rb
@@ -45,7 +45,7 @@ module OneGadget
         return __send__(:"inst_#{mnem}", rest) != :fail if %w[push pop].include?(mnem)
 
         inst, args = parse(body)
-        __send__(:"inst_#{inst.inst}", *args) != :fail
+        __send__(inst.handler, *args) != :fail
       end
 
       # The flag-setting spelling of an instruction we model, which differs from

--- a/lib/one_gadget/emulators/instruction.rb
+++ b/lib/one_gadget/emulators/instruction.rb
@@ -46,7 +46,28 @@ module OneGadget
       # @param [String] cmd One line of objdump output.
       # @return [Boolean] +true+ if +cmd+ contains this instruction's mnemonic.
       def match?(cmd)
-        (cmd =~ /#{inst}\s/) != nil
+        cmd.match?(/#{Regexp.escape(inst)}\s/)
+      end
+
+      class << self
+        # The emulator method that runs +mnemonic+. A mnemonic is not always a
+        # method name -- one can carry a suffix spelled with a dot -- so the dots
+        # become underscores. Named here, rather than at each dispatch, so an
+        # emulator defining a family of handlers at once agrees with the dispatcher
+        # about what to call them.
+        # @param [String] mnemonic
+        # @return [Symbol]
+        # @example
+        #   Instruction.handler_name('mov')     #=> :inst_mov
+        #   Instruction.handler_name('sext.w')  #=> :inst_sext_w
+        def handler_name(mnemonic) = :"inst_#{mnemonic.tr('.', '_')}"
+      end
+
+      # The emulator method that runs this instruction.
+      # @return [Symbol]
+      # @see .handler_name
+      def handler
+        @handler ||= self.class.handler_name(inst)
       end
 
       private

--- a/lib/one_gadget/emulators/x86.rb
+++ b/lib/one_gadget/emulators/x86.rb
@@ -30,8 +30,7 @@ module OneGadget
         return handle_branch(mnem, cmd) != :fail if branch_mnem?(mnem)
 
         inst, args = parse(cmd)
-        sym = :"inst_#{inst.inst}"
-        __send__(sym, *args) != :fail
+        __send__(inst.handler, *args) != :fail
       end
 
       # x86 conditional-jump mnemonics mapped to shared {Conditional::RELATION}

--- a/spec/emulators/instruction_spec.rb
+++ b/spec/emulators/instruction_spec.rb
@@ -9,12 +9,23 @@ describe OneGadget::Emulators::Instruction do
     @add = OneGadget::Emulators::Instruction.new('add', 2)
     @lea = OneGadget::Emulators::Instruction.new('lea', 2)
     @call = OneGadget::Emulators::Instruction.new('call', 1)
+    @sext = OneGadget::Emulators::Instruction.new('sext.w', 2)
   end
 
   it 'match?' do
     expect(@add.match?('add rax, rax')).to be true
     expect(@add.match?('41f11:       addr32 call c4590 <execve>')).to be false
     expect(@call.match?('41f11:       addr32 call c4590 <execve>')).to be true
+    # the dot is this mnemonic's own character, not "any character"
+    expect(@sext.match?('a3f04:       0007879b        sext.w  a5,a5')).to be true
+    expect(@sext.match?('a3f04:       0007879b        sextxw  a5,a5')).to be false
+  end
+
+  it 'handler' do
+    expect(@mov.handler).to be :inst_mov
+    expect(@sext.handler).to be :inst_sext_w
+    # the same naming an emulator uses when it defines a family of handlers at once
+    expect(described_class.handler_name('zext.b')).to be :inst_zext_b
   end
 
   it 'fetch_args' do


### PR DESCRIPTION
A mnemonic is not always a method name: RISC-V spells a suffix with a dot (sext.w, lr.w.aq), which no emulator can declare a handler for. Instruction names the handler for a mnemonic, converting the dots, so an emulator dispatches on that rather than interpolating the mnemonic itself. The conversion is a class method as well, since an emulator defining a family of handlers at once -- the sext/zext widths, say -- has to agree with the dispatcher about their names.

The same dot was also being spliced raw into match?'s regex, where it matched any character -- harmless for today's mnemonics, none of which contain one, but it would have let "sext.w" claim a "sextxw" line.