### PR TITLE
Give the $base-relative string hooks a default in Base

### DIFF
--- a/docs/adding-an-architecture.md
+++ b/docs/adding-an-architecture.md
@@ -108,6 +108,12 @@ Reading the flow:
 | `str_bin_sh?(operand)` | does this operand reference the `"/bin/sh"` string? |
 | `str_sh?(operand)` | does it reference the standalone `"sh"` string? |
 | `global_var?(operand)` | does it reference a libc global (i.e. is it `$base`-relative)? |
+
+The last three have defaults in `Base` that read the `$base`-relative form an arch
+produces once it concretizes a pc-relative operand, so an arch that renders
+addresses that way (aarch64, arm, amd64) implements none of them. Override
+them only where the address reads differently — i386 reaches a global through its
+GOT register, so all three are its own.
 | `branch_kind(line)` | classify an instruction: `:conditional`, `:unconditional`, `:terminator`, or `nil` (not a branch) |
 | `branch_lead_chars` | the leading character(s) of this arch's branch mnemonics, e.g. `'bct'` or `'j'` (a cheap filter) |
 

--- a/lib/one_gadget/fetchers/aarch64.rb
+++ b/lib/one_gadget/fetchers/aarch64.rb
@@ -46,33 +46,6 @@ module OneGadget
       def call_str
         'bl'
       end
-
-      def bin_sh_offset
-        @bin_sh_offset ||= str_offset('/bin/sh')
-      end
-
-      def str_bin_sh?(str)
-        str.include?('$base') && str.include?(bin_sh_offset.to_s(16))
-      end
-
-      # Offset of the standalone "sh" string (\0-preceded and \0-terminated) that
-      # glibc passes as argv[0] in execl("/bin/sh", "sh", ...). Its distance from
-      # "/bin/sh" is build-specific, so locate it directly instead of guessing.
-      # +nil+ when the libc has no such string.
-      def sh_offset
-        return @sh_offset if defined?(@sh_offset)
-
-        idx = File.binread(file).index("\x00sh\x00")
-        @sh_offset = idx && idx + 1
-      end
-
-      def str_sh?(str)
-        !sh_offset.nil? && str.include?('$base') && str.include?(sh_offset.to_s(16))
-      end
-
-      def global_var?(str)
-        base_relative?(str, '$base')
-      end
     end
   end
 end

--- a/lib/one_gadget/fetchers/amd64.rb
+++ b/lib/one_gadget/fetchers/amd64.rb
@@ -18,23 +18,11 @@ module OneGadget
       def candidates
         super do |candidate|
           next true if candidate.include?('posix_spawn@')
-          next false unless candidate.include?(bin_sh_hex) # works in x86-64
+          next false unless candidate.include?(bin_sh_offset.to_s(16)) # works in x86-64
           next false unless candidate.lines.last.include?('execve') # only care execve
 
           true
         end
-      end
-
-      def bin_sh_hex
-        @bin_sh_hex ||= str_offset('/bin/sh').to_s(16)
-      end
-
-      def str_bin_sh?(str)
-        str.include?('$base') && str.include?(bin_sh_hex)
-      end
-
-      def global_var?(str)
-        base_relative?(str, '$base')
       end
     end
   end

--- a/lib/one_gadget/fetchers/arm.rb
+++ b/lib/one_gadget/fetchers/arm.rb
@@ -224,33 +224,6 @@ module OneGadget
       def call_str
         'bl'
       end
-
-      def bin_sh_offset
-        @bin_sh_offset ||= str_offset('/bin/sh')
-      end
-
-      def str_bin_sh?(str)
-        str.include?('$base') && str.include?(bin_sh_offset.to_s(16))
-      end
-
-      # Offset of the standalone "sh" string (\0-preceded and \0-terminated) that
-      # glibc passes as argv[0] in execl("/bin/sh", "sh", ...). Its distance from
-      # "/bin/sh" is build-specific, so locate it directly instead of guessing.
-      # +nil+ when the libc has no such string.
-      def sh_offset
-        return @sh_offset if defined?(@sh_offset)
-
-        idx = File.binread(file).index("\x00sh\x00")
-        @sh_offset = idx && idx + 1
-      end
-
-      def str_sh?(str)
-        !sh_offset.nil? && str.include?('$base') && str.include?(sh_offset.to_s(16))
-      end
-
-      def global_var?(str)
-        base_relative?(str, '$base')
-      end
     end
   end
 end

--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -143,7 +143,14 @@ module OneGadget
 
       private
 
-      def global_var?(_str); raise NotImplementedError
+      # Whether +str+ references a libc global, i.e. an address the caller does not
+      # choose. The default reads the +$base+-relative form an arch produces once it
+      # concretizes a pc-relative operand; one that reaches its globals through a
+      # register (i386's GOT) overrides this against that register instead.
+      # @param [String] str A rendered value.
+      # @return [Boolean]
+      def global_var?(str)
+        base_relative?(str, '$base')
       end
 
       # Whether +str+ names a value at a fixed offset from +base+, i.e. an address
@@ -179,10 +186,38 @@ module OneGadget
         "#{holder} is the GOT address of libc"
       end
 
-      def str_bin_sh?(_str); raise NotImplementedError
+      # Whether +str+ references the +"/bin/sh"+ string. The default recognises the
+      # +$base+-relative form (see {#global_var?}); an arch that renders the address
+      # differently overrides it.
+      # @param [String] str A rendered value.
+      # @return [Boolean]
+      def str_bin_sh?(str)
+        str.include?('$base') && str.include?(bin_sh_offset.to_s(16))
       end
 
-      def str_sh?(_str); raise NotImplementedError
+      # Whether +str+ references the standalone +"sh"+ string glibc passes as
+      # argv[0] in +execl("/bin/sh", "sh", ...)+. False for a libc that has none.
+      # @param [String] str A rendered value.
+      # @return [Boolean]
+      def str_sh?(str)
+        !sh_offset.nil? && str.include?('$base') && str.include?(sh_offset.to_s(16))
+      end
+
+      # File offset of the +"/bin/sh"+ string.
+      # @return [Integer]
+      def bin_sh_offset
+        @bin_sh_offset ||= str_offset('/bin/sh')
+      end
+
+      # File offset of the standalone +"sh"+ string (\0-preceded and
+      # \0-terminated). Its distance from +"/bin/sh"+ is build-specific, so locate
+      # it directly instead of guessing.
+      # @return [Integer?] +nil+ when the libc has no such string.
+      def sh_offset
+        return @sh_offset if defined?(@sh_offset)
+
+        idx = file_bytes.index("\x00sh\x00")
+        @sh_offset = idx && idx + 1
       end
 
       def call_str; raise NotImplementedError


### PR DESCRIPTION
str_bin_sh?, str_sh? and global_var? were declared abstract, then implemented identically by arm and aarch64 -- byte for byte -- with amd64 carrying the same str_bin_sh?/global_var? under a differently named offset cache. Three of the four arches agree because they all reach a string the same way: they concretize a pc-relative operand into $base+off, and the hook just asks whether the rendered value is that.

So that becomes the default, along with the two offset lookups behind it, and the three copies go. i386 keeps its own: it reaches a global through the GOT register, which is what makes it the exception rather than one more copy.

amd64 gains a working str_sh? it never had (it would have raised had a path reached it; none does). The corpus is byte-identical at levels 0/1/2.