### PR TITLE
Emulate riscv64's loads and stores

### DIFF
--- a/lib/one_gadget/emulators/riscv64.rb
+++ b/lib/one_gadget/emulators/riscv64.rb
@@ -25,6 +25,14 @@ module OneGadget
         __send__(inst.handler, *args) != :fail
       end
 
+      # The loads, mapped to how many bytes each reads.
+      LOADS = { 'ld' => 8, 'lw' => 4, 'lwu' => 4, 'lh' => 2, 'lhu' => 2, 'lb' => 1, 'lbu' => 1 }.freeze
+      private_constant :LOADS
+
+      # The stores, mapped to how many bytes each writes.
+      STORES = { 'sd' => 8, 'sw' => 4, 'sh' => 2, 'sb' => 1 }.freeze
+      private_constant :STORES
+
       # Supported instruction set. Anything not listed aborts the candidate.
       # @return [Array<Instruction>] The supported instructions.
       def instructions
@@ -38,7 +46,7 @@ module OneGadget
           Instruction.new('mv', 2),
           Instruction.new('nop', 0),
           Instruction.new('sub', 3)
-        ]
+        ] + (LOADS.keys + STORES.keys).map { |mnem| Instruction.new(mnem, 2) }
       end
 
       # Return the argument value of calling a function.
@@ -104,6 +112,63 @@ module OneGadget
         check_register!(dst)
 
         registers[dst] = arg_to_lambda(src)
+      end
+
+      # Each load and store handled the one way, since within a family they differ
+      # only in the width they touch (see {#load_value} and {#store_value}).
+      LOADS.each do |mnem, size|
+        define_method(Instruction.handler_name(mnem)) { |dst, mem| load_value(dst, mem, size) }
+      end
+      STORES.each do |mnem, size|
+        define_method(Instruction.handler_name(mnem)) { |src, mem| store_value(src, mem, size) }
+      end
+
+      # A load. The address is read like any other, so what the caller has to
+      # arrange about it is recorded the same way. A load narrower than a register
+      # only takes part of the word this emulator tracks, which is not a value it
+      # can name, so the register then holds what a call would have left: a path
+      # that goes on to depend on it is abandoned rather than described wrongly.
+      # @param [String] dst The destination register.
+      # @param [String] mem The memory operand, as written.
+      # @param [Integer] size How many bytes the load reads.
+      # @return [void]
+      def load_value(dst, mem, size)
+        check_register!(dst)
+
+        value = read_value(arg_to_lambda(mem_operand(mem)))
+        registers[dst] = size == size_t ? value : clobbered_value
+      end
+
+      # A store, tracked so a later load of the same slot reads it back, and
+      # requiring its target writable ({Processor#track_write}). A store narrower
+      # than a register leaves the rest of the slot holding whatever was there, so
+      # what the slot then holds is named as unknown rather than as the value
+      # stored -- the requirement that it be writable is what the candidate really
+      # establishes, and that is kept.
+      # @param [String] src The register holding the value stored.
+      # @param [String] mem The memory operand, as written.
+      # @param [Integer] size How many bytes the store writes.
+      # @return [void]
+      def store_value(src, mem, size)
+        check_register!(src)
+
+        dst_l = arg_to_lambda(mem_operand(mem)).ref!
+        track_write(dst_l, size == size_t ? registers[src] : clobbered_value)
+      end
+
+      # This arch writes a memory operand as an offset applied to one register,
+      # which the {Lambda} parser reads in its bracketed form. The offset is
+      # decimal, as objdump prints every operand but an upper immediate.
+      # @param [String] mem The operand, as written.
+      # @return [String]
+      # @example
+      #   mem_operand('-1230(a5)') #=> '[a5-1230]'
+      #   mem_operand('0(s1)')     #=> '[s1+0]'
+      def mem_operand(mem)
+        m = mem.match(/\A(-?\d+)\((\w+)\)\z/)
+        raise_unsupported('memory operand', mem) if m.nil?
+
+        "[#{m[2]}#{format('%+d', Integer(m[1]))}]"
       end
 
       # The value +pc+ holds while the instruction at {@cur_addr} runs: this arch

--- a/spec/one_gadget_riscv64_spec.rb
+++ b/spec/one_gadget_riscv64_spec.rb
@@ -11,8 +11,20 @@ describe 'one_gadget_riscv64' do
     it 'libc-2.39' do
       path = data_path('riscv64-libc-2.39.so')
       expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x9f738, 0x9f73a, 0x9f73c]
-      expect(OneGadget.gadgets(file: path, force_file: true, level: 2))
-        .to eq [0x9f738, 0x9f73a, 0x9f73c, 0xb5762, 0xb5764, 0xb5766]
+      expect(OneGadget.gadgets(file: path, force_file: true, level: 1))
+        .to eq [0x46df2, 0x46e12, 0x46e20, 0x46e24, 0x46e26, 0x46e2a, 0x46e2e, 0x46e30, 0x46e32,
+                0x46e3c, 0x625dc, 0x625e8, 0x625ec, 0x625ee, 0x625f2, 0x625f6, 0x625fa, 0x625fe,
+                0x6260a, 0x9f738, 0x9f73a, 0x9f73c, 0xb575a, 0xb5760, 0xb5762, 0xb5764]
+    end
+
+    it 'stages an argv on the stack and requires it writable' do
+      path = data_path('riscv64-libc-2.39.so')
+      gadget = OneGadget.gadgets(file: path, force_file: true, details: true, level: 1)
+                        .find { |g| g.offset == 0x625e8 }
+      # posix_spawn's file_actions/attr are staged through s0 and s1, neither of
+      # which is invariantly writable the way sp is, so both stay preconditions.
+      expect(gadget.constraints).to include('writable: s0-0xf0')
+      expect(gadget.constraints).to include('s1+0xe0 == NULL || writable: s1+0xe0')
     end
 
     it 'resolves the auipc/addi pair that names "/bin/sh"' do


### PR DESCRIPTION
The blockers this clears were the top of the list: ld (12) and sd (7) of the candidates that reach a terminal call, with lw behind them. Level 1 goes from 5 gadgets to 26 and level 2 from 6 to 51; level 0 is unchanged at 3.

Both families are one handler each, keyed by the width they touch, because that width is the only thing that differs within a family. A load or store of a whole register is nameable and is tracked. A narrower one is not: a partial load takes part of a word this emulator tracks whole, and a partial store leaves the rest of the slot holding whatever the caller left there. Both keep what the candidate really establishes -- the address is read, or has to be writable -- and name the value as unknown rather than as one they cannot justify.

A memory operand is an offset applied to one register, spelled off(reg), which is rewritten into the bracketed form the Lambda parser reads. The offset is decimal: objdump prints every operand of this arch that way except an upper immediate.

Blockers are now the branches -- j (10), beq (6), bnez (6), bne (6), beqz (5) -- which is the next change. The other four architectures are byte-identical.