### PR TITLE
Turn a riscv64 branch into a gadget constraint

### DIFF
--- a/lib/one_gadget/emulators/riscv64.rb
+++ b/lib/one_gadget/emulators/riscv64.rb
@@ -21,9 +21,27 @@ module OneGadget
         resolve_pending_branch(cmd)
         @cur_addr = cmd[/\A\s*([0-9a-f]+):/, 1]&.to_i(16)
 
+        mnem = mnemonic(cmd)
+        return handle_branch(mnem, cmd) != :fail if branch_mnem?(mnem)
+
         inst, args = parse(cmd)
         __send__(inst.handler, *args) != :fail
       end
+
+      # A conditional branch of this arch compares its operands itself -- there is
+      # no flag register and no compare instruction -- so each mnemonic names the
+      # relation the operands must stand in for the branch to be taken. The
+      # assembler's spellings against zero (+beqz+, +blez+, ...) name one register
+      # and the reversed ones (+bgt+, +ble+, ...) read a relation the other way
+      # round; each is listed as the relation it states, so a constraint reads as
+      # the comparison was written.
+      COND = {
+        'beq' => :eq, 'bne' => :ne,
+        'blt' => :slt, 'bge' => :sge, 'bltu' => :ult, 'bgeu' => :uge,
+        'bgt' => :sgt, 'ble' => :sle, 'bgtu' => :ugt, 'bleu' => :ule,
+        'beqz' => :eq, 'bnez' => :ne,
+        'bltz' => :slt, 'bgez' => :sge, 'blez' => :sle, 'bgtz' => :sgt
+      }.freeze
 
       # The loads, mapped to how many bytes each reads.
       LOADS = { 'ld' => 8, 'lw' => 4, 'lwu' => 4, 'lh' => 2, 'lhu' => 2, 'lb' => 1, 'lbu' => 1 }.freeze
@@ -57,6 +75,27 @@ module OneGadget
       end
 
       private
+
+      def branch_mnem?(mnem)
+        mnem == 'j' || COND.key?(mnem)
+      end
+
+      # Operands of +cmd+ (mnemonic dropped), each stripped of a trailing +<symbol>+.
+      def operands(cmd)
+        cmd.sub(/\A[0-9a-f]+:\s*\S+\s*/, '').split(',').map { |o| o.strip.sub(/\s*<.*>\z/, '') }
+      end
+
+      # Record the comparison and decide the branch together, since one
+      # instruction is both (see {COND}). The zero spellings leave their second
+      # operand out; +zero+ names it, and reads as the +0x0+ it holds.
+      def handle_branch(mnem, cmd)
+        return true if mnem == 'j' # unconditional: control handled by the stitched path
+
+        ops = operands(cmd)
+        lhs, rhs = mnem.end_with?('z') ? [ops[0], 'zero'] : ops[0..1]
+        record_compare(:sub, operand_str(lhs), operand_str(rhs))
+        branch_on_compare(COND[mnem], ops.last.to_i(16))
+      end
 
       # A direct call: record the terminal +exec*+ target, accept a known-safe
       # syscall wrapper, or +:fail+ to abort the candidate. The two-operand form

--- a/spec/emulators/riscv64_spec.rb
+++ b/spec/emulators/riscv64_spec.rb
@@ -38,6 +38,41 @@ describe OneGadget::Emulators::Riscv64 do
     expect(@processor.registers['a3'].to_s).to eq '(a1+0x8 + a1+0x8)'
   end
 
+  describe 'conditional branches' do
+    # Feed the branch, then a follow-up line whose address decides taken
+    # (== target) vs not-taken (!= target).
+    def branch_constraint(branch, target, follow_addr)
+      @processor.process("1000: #{branch} #{format('%x', target)} <x>")
+      @processor.process("#{format('%x', follow_addr)}: nop")
+      @processor.constraints
+    end
+
+    it 'compares and branches in the one instruction' do
+      expect(branch_constraint('bne a2,a4,', 0x2000, 0x1004)).to eq ['a2 == a4'] # not taken
+      @processor = described_class.new
+      expect(branch_constraint('beq a2,a4,', 0x2000, 0x2000)).to eq ['a2 == a4'] # taken
+    end
+
+    it 'reads a comparison against zero off the register that names it' do
+      expect(branch_constraint('beqz a3,', 0x2000, 0x2000)).to eq ['a3 == 0x0'] # taken
+      @processor = described_class.new
+      expect(branch_constraint('bnez a3,', 0x2000, 0x2000)).to eq ['a3 != 0x0'] # taken
+    end
+
+    it 'states a reversed spelling as the relation it reads' do
+      expect(branch_constraint('bgt a0,a1,', 0x2000, 0x2000)).to eq ['(s64)a0 > a1'] # taken
+      @processor = described_class.new
+      expect(branch_constraint('bleu a0,a1,', 0x2000, 0x1004)).to eq ['(u64)a0 > a1'] # not taken
+      @processor = described_class.new
+      expect(branch_constraint('blez a0,', 0x2000, 0x2000)).to eq ['(s64)a0 <= 0x0'] # taken
+    end
+
+    it 'takes an unconditional jump without constraining anything' do
+      expect(@processor.process('1000: j 2000 <x>')).to be true
+      expect(@processor.constraints).to eq []
+    end
+  end
+
   it 'holds zero in the hardwired register' do
     expect(@processor.registers['zero']).to be 0
   end

--- a/spec/one_gadget_riscv64_spec.rb
+++ b/spec/one_gadget_riscv64_spec.rb
@@ -10,11 +10,12 @@ describe 'one_gadget_riscv64' do
 
     it 'libc-2.39' do
       path = data_path('riscv64-libc-2.39.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x9f738, 0x9f73a, 0x9f73c]
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x9f73a, 0x9f73c, 0x9f778, 0xb5adc]
       expect(OneGadget.gadgets(file: path, force_file: true, level: 1))
         .to eq [0x46df2, 0x46e12, 0x46e20, 0x46e24, 0x46e26, 0x46e2a, 0x46e2e, 0x46e30, 0x46e32,
                 0x46e3c, 0x625dc, 0x625e8, 0x625ec, 0x625ee, 0x625f2, 0x625f6, 0x625fa, 0x625fe,
-                0x6260a, 0x9f738, 0x9f73a, 0x9f73c, 0xb575a, 0xb5760, 0xb5762, 0xb5764]
+                0x6260a, 0x9f6d6, 0x9f6ec, 0x9f720, 0x9f726, 0x9f72a, 0x9f73a, 0x9f73c, 0x9f778,
+                0x9f78c, 0x9f790, 0x9f794, 0x9f798, 0x9f79c, 0xb5762, 0xb5764, 0xb5adc]
     end
 
     it 'stages an argv on the stack and requires it writable' do
@@ -25,6 +26,16 @@ describe 'one_gadget_riscv64' do
       # which is invariantly writable the way sp is, so both stay preconditions.
       expect(gadget.constraints).to include('writable: s0-0xf0')
       expect(gadget.constraints).to include('s1+0xe0 == NULL || writable: s1+0xe0')
+    end
+
+    it 'states the branch a gadget is only reached through' do
+      path = data_path('riscv64-libc-2.39.so')
+      gadget = OneGadget.gadgets(file: path, force_file: true, details: true, level: 1)
+                        .find { |g| g.offset == 0x9f720 }
+      # execl's loop reaches this window only when the argument count it compares
+      # against holds, and a2 is what the caller has to arrange for that.
+      expect(gadget.constraints).to include('a2 == 0x1')
+      expect(gadget.effect).to eq 'execve("/bin/sh", sp, s2)'
     end
 
     it 'resolves the auipc/addi pair that names "/bin/sh"' do


### PR DESCRIPTION
This arch has no flag register and no compare instruction: a conditional branch compares its two operands itself. So the emulator records the comparison and decides the branch in the one instruction, and every branch mnemonic is listed as the relation its operands must stand in for it to be taken -- including the assembler's spellings against zero (beqz, blez) and the reversed ones (bgt, ble), each stating the relation it reads rather than being rewritten into a canonical form the disassembly never showed.

Nothing new was needed from the shared branch machinery, which was the question worth answering: record_compare and branch_on_compare already take a comparison and a decision separately, and one instruction supplying both is fine.

Level 1 goes from 26 gadgets to 35 and level 2 from 51 to 116, and the new ones carry what the branch says -- "a2 == 0x1", "[a1] == 0x0" -- beside the argv the window builds. Level 0 goes from 3 to 4.

Blockers left are the rest of the ALU: andi (6), xor (5), sext.w (4), addiw (4), then one each of ori, snez and sltu. The other four architectures are byte-identical.