### PR TITLE
Verify riscv64 gadgets with Aletheia

### DIFF
--- a/aletheia/README.md
+++ b/aletheia/README.md
@@ -10,14 +10,16 @@ part of the published gem.
 
 ## Status
 
-Verifies amd64, i386, arm, and aarch64. The backend is picked from the target ELF's machine,
+Verifies amd64, i386, arm, aarch64, and riscv64. The backend is picked from the target ELF's machine,
 and the transport from the *host* arch: the arch that matches the host runs natively, the rest
 under qemu-user — so the same suite works on any host (an aarch64 host runs aarch64 natively and
 the others under qemu; an x86_64 host does the reverse). arm runs via stub self-injection (no
 gdbstub); its `execve` gadgets verify, but `posix_spawn` gadgets are SKIPped because qemu-arm
 lacks the `clone3` syscall glibc uses to fork (see `docs/DESIGN.md`). Set `ALETHEIA_FORCE_QEMU=1`
-to run a native arch under qemu too. Other architectures plug in behind `Aletheia::Arch` — see
-`docs/ADDING-AN-ARCH.md`.
+to run a native arch under qemu too. riscv64 answers L2 only: gdb has no syscall catchpoint on
+that architecture, so nothing stops at the `execve` entry and the L0 signal goes unanswered — the
+verdict still comes from a real shell running `ls /`, which is what decides PASS anyway. Other
+architectures plug in behind `Aletheia::Arch` — see `docs/ADDING-AN-ARCH.md`.
 
 ## Prerequisites
 

--- a/aletheia/build_stubs.sh
+++ b/aletheia/build_stubs.sh
@@ -22,6 +22,7 @@ build() {
 case "$(uname -m)" in
   aarch64) build cc park_stub_aarch64 ;;
   x86_64)  build cc park_stub_x86_64 ;;
+  riscv64) build cc park_stub_riscv64 ;;
   *) echo "unknown host arch $(uname -m); build a stub manually" >&2 ;;
 esac
 
@@ -30,4 +31,5 @@ esac
 [ "$(uname -m)" = x86_64 ]  && build aarch64-linux-gnu-gcc park_stub_aarch64
 build i686-linux-gnu-gcc park_stub_i386 # i386 (32-bit) is always cross-built
 build arm-linux-gnueabihf-gcc park_stub_arm # armhf (32-bit) is always cross-built
+build riscv64-linux-gnu-gcc park_stub_riscv64 # cross-built unless the host is riscv64 itself
 exit 0

--- a/aletheia/build_sysroot.sh
+++ b/aletheia/build_sysroot.sh
@@ -22,6 +22,7 @@ case "$arch" in
   arm)     deb_arch=armhf; triplet=arm-linux-gnueabihf; cc=arm-linux-gnueabihf-gcc; ldso=ld-linux-armhf.so.3 ;;
   aarch64) deb_arch=arm64; triplet=aarch64-linux-gnu;   cc=aarch64-linux-gnu-gcc;   ldso=ld-linux-aarch64.so.1 ;;
   amd64)   deb_arch=amd64; triplet=x86_64-linux-gnu;    cc=x86_64-linux-gnu-gcc;    ldso=ld-linux-x86-64.so.2 ;;
+  riscv64) deb_arch=riscv64; triplet=riscv64-linux-gnu; cc=riscv64-linux-gnu-gcc; ldso=ld-linux-riscv64-lp64d.so.1 ;;
   *) echo "unsupported arch $arch" >&2; exit 2 ;;
 esac
 dl=-l:libdl.so.2

--- a/aletheia/driver.py
+++ b/aletheia/driver.py
@@ -165,7 +165,14 @@ def execd_shell(pid):
 # ever fire in the (non-execing) parent -- useless there, and qemu-aarch64's
 # gdbstub SIGSEGVs some straight-line execl() paths when it's armed regardless
 # (reproduced: works cleanly without it, corrupts execl with it).
-gdb.execute("catch syscall execve execveat")
+# Not every architecture has a syscall catchpoint in gdb (RISC-V is one). Where it
+# is missing, nothing stops at the syscall entry and L0 goes unanswered -- the run
+# still reaches the shell, and L2 (a real shell running `ls /`) is what decides the
+# verdict anyway.
+try:
+    gdb.execute("catch syscall execve execveat")
+except gdb.error:
+    pass
 if connect == "run":
     try:
         gdb.execute("catch exec")
@@ -185,6 +192,11 @@ if not l0 and connect == "run":
     l0 = execd_shell(gdb.selected_inferior().pid)
 gdb.write("ALETHEIA_L0=%s\n" % ("pass" if l0 else "fail"))
 
-# Let the shell run for the L2 (`ls /`) check on the tty.
+# Let the shell run for the L2 (`ls /`) check on the tty. With no catchpoint armed
+# the continue above already ran to the shell, so there may be nothing left to
+# resume.
 gdb.execute("delete")
-gdb.execute("continue")
+try:
+    gdb.execute("continue")
+except gdb.error:
+    pass

--- a/aletheia/lib/aletheia/arch/riscv64.rb
+++ b/aletheia/lib/aletheia/arch/riscv64.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Aletheia
+  module Arch
+    # RISC-V (RV64) backend. Runs under qemu-user; the exec* arguments reach the
+    # kernel the same way aarch64's do -- the generic unistd numbers in +a7+, the
+    # arguments in +a0..a2+.
+    module Riscv64
+      module_function
+
+      def name = 'riscv64'
+
+      # General-purpose registers the satisfier may assign / the driver fills.
+      # +zero+ is hardwired and +sp+ is the stack; +gp+ and +tp+ are left out as
+      # well, because the parked stub is a live process whose libc reaches its
+      # thread-local storage through +tp+ -- poisoning it breaks the very libc the
+      # gadget is about to run in, which is a harness failure, not a gadget one.
+      def gprs
+        %w[ra] + (0..7).map { |i| "a#{i}" } + (0..11).map { |i| "s#{i}" } +
+          (0..6).map { |i| "t#{i}" }
+      end
+
+      # Only +sp+ invariantly names a live stack address that can't be NULL; +s0+
+      # is the frame pointer by convention but a general register the attacker
+      # controls in these gadgets (like aarch64's +x29+), so a store through it
+      # carries an explicit +writable: s0+imm+ constraint rather than being assumed
+      # valid.
+      def stack_regs = %w[sp]
+
+      def sp = 'sp'
+      def pc = 'pc'
+
+      # Whether this backend can run the target libc natively on the host.
+      # @param [String] host_machine value of +uname -m+
+      def native_on?(host_machine) = host_machine == 'riscv64'
+
+      # Under qemu, a libc whose version differs from the cross toolchain's needs a
+      # per-version sysroot (its init crashes under a newer ld.so); the matched one
+      # loads directly.
+      def version_strict? = true
+
+      # gdb register expression for GPR +name+. gdb answers to the ABI names the
+      # disassembly uses, and they alias the numbered ones ($a0 is $x10).
+      def gdb_reg(name) = "$#{name}"
+
+      # This arch spells no register more than one way: objdump emits neither the
+      # numbered +x0+-+x31+ names nor +fp+ for +s0+, so a name arrives as itself.
+      def normalize_reg(reg) = reg
+
+      # park_stub binary for this arch (built by the build helper).
+      def stub_binary = 'park_stub_riscv64'
+
+      # qemu-user transport config: emulator binary, the sysroot providing the
+      # stub's own ld.so + libc (QEMU_LD_PREFIX), and the gdb architecture to select.
+      def qemu
+        { 'bin' => 'qemu-riscv64', 'ld_prefix' => '/usr/riscv64-linux-gnu',
+          'gdb_arch' => 'riscv:rv64' }
+      end
+
+      # Register/syscall model the gdb driver needs (serialized into the plan).
+      def driver_model
+        { 'gprs' => gprs, 'sp' => sp, 'pc' => pc, 'gdb_arch' => 'riscv:rv64', 'word_size' => 8,
+          'sysno_reg' => 'a7', 'execve_syscalls' => [221, 281],
+          'path_reg' => 'a0', 'argv_reg' => 'a1', 'envp_reg' => 'a2' }
+      end
+    end
+  end
+end

--- a/aletheia/lib/aletheia/runner.rb
+++ b/aletheia/lib/aletheia/runner.rb
@@ -8,6 +8,7 @@ require_relative 'arch/aarch64'
 require_relative 'arch/amd64'
 require_relative 'arch/i386'
 require_relative 'arch/arm'
+require_relative 'arch/riscv64'
 require_relative 'satisfier'
 require_relative 'oracle'
 
@@ -22,7 +23,8 @@ module Aletheia
   #   SKIP  - the satisfier could not produce a plan (a harness limitation, not
   #           a verdict on the gadget)
   class Runner
-    ARCHES = { amd64: Arch::Amd64, i386: Arch::I386, arm: Arch::Arm, aarch64: Arch::AArch64 }.freeze
+    ARCHES = { amd64: Arch::Amd64, i386: Arch::I386, arm: Arch::Arm, aarch64: Arch::AArch64,
+               riscv64: Arch::Riscv64 }.freeze
 
     # The mapping granularity a loader rounds a segment up to. The smallest any
     # target uses, so the spare tail it implies is mapped whatever the real page

--- a/tasks/aletheia.rake
+++ b/tasks/aletheia.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ARCHES = %w[aarch64 amd64 arm i386].freeze
+ARCHES = %w[aarch64 amd64 arm i386 riscv64].freeze
 FIXTURES = 'spec/data/*.so'
 
 namespace :aletheia do


### PR DESCRIPTION
The backend is the declarative part -- register model, qemu config, and the syscall/argument registers the driver needs, which are aarch64's generic-unistd numbers again (221/281 in a7, arguments in a0-a2). gp and tp are kept out of the assignable set: the parked stub is a live process whose libc reaches its thread-local storage through tp, so poisoning it breaks the libc the gadget is about to run in, which would be a harness failure wearing a gadget's clothes.

driver.py needed a real change. gdb has no syscall catchpoint on this architecture, and the exception from arming one killed the driver script before the continue that runs the gadget -- reading as "no execve and no shell output" against four gadgets that were fine. It is now optional, the way catch exec below it already was, so riscv64 answers L2 only: nothing stops at the syscall entry, and the verdict comes from a real shell running `ls /`, which is what decides PASS anyway.

Verified strict: level 0 4 PASS, level 1 38 PASS, level 2 141 PASS / 30 SKIP / 0 FAIL. Every SKIP is the satisfier declining a writable constraint on a derived address it cannot steer -- ((a5 << 0x3) + [sp+0xd0]) and its like -- which is a harness limit, not a verdict. The negative control, that same satisfiable plan aimed at an offset that is not a gadget, FAILs. aarch64 (18 PASS) and i386 (20 PASS) re-verify unchanged after the driver change.