### PR TITLE
Find riscv64's call sites without disassembling the whole libc

### DIFF
--- a/lib/one_gadget/fetchers/riscv64.rb
+++ b/lib/one_gadget/fetchers/riscv64.rb
@@ -9,6 +9,43 @@ module OneGadget
     class Riscv64 < Base
       private
 
+      # +jal+ is the only direct call and is four bytes wide, carrying its target as
+      # a signed offset from itself. Instructions are two-byte aligned, since a
+      # compressed one is half a word, so every two-byte position is read as a
+      # possible +jal+ rather than every fourth: a false positive only adds a
+      # window nothing is found in, while a missed call costs the gadgets around it.
+      def scan_calls(base, data, targets)
+        halves = data.unpack('v*')
+        sites = []
+        halves.each_with_index do |low, i|
+          next unless (low & 0x7f) == JAL_OPCODE
+
+          high = halves[i + 1]
+          break if high.nil?
+
+          addr = base + (i * 2)
+          sites << addr if targets.key?(addr + jal_offset(low | (high << 16)))
+        end
+        sites
+      end
+
+      # The J-type opcode, which lives in the low half of the instruction word.
+      JAL_OPCODE = 0x6f
+      private_constant :JAL_OPCODE
+
+      # The signed offset a +jal+ carries. The encoding scatters its bits --
+      # +[20|10:1|11|19:12]+, with bit 0 always zero since a target is two-byte
+      # aligned -- so they are put back in order before the sign is applied.
+      # @param [Integer] word The instruction word.
+      # @return [Integer]
+      def jal_offset(word)
+        imm = (((word >> 31) & 0x1) << 20) |
+              (((word >> 12) & 0xff) << 12) |
+              (((word >> 20) & 0x1) << 11) |
+              (((word >> 21) & 0x3ff) << 1)
+        imm.anybits?(1 << 20) ? imm - (1 << 21) : imm
+      end
+
       def emulator
         OneGadget::Emulators::Riscv64.new
       end


### PR DESCRIPTION
Level 2 on the 2.39 fixture goes from 3.7s to 0.93s, because only the windows around a terminal call are disassembled rather than 316k instructions.

jal is the only direct call and is four bytes wide, but instructions are two-byte aligned -- a compressed one is half a word -- so every two-byte position is read as a possible jal rather than every fourth. That is allowed to over-approximate, and on this fixture it does not have to: 26 real call sites into the target symbols, 26 found, none missed and nothing extra. The gadgets are byte-identical at levels 0/1/2, which is the check that matters, since a missed call costs every gadget around it.