### PR TITLE
Announce riscv64 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Notable changes to one_gadget, newest first. The format follows
 A change worth a user's attention lands with its entry under *Unreleased*;
 releases are cut by giving that section a version and a date.
 
+## Unreleased
+
+### Added
+
+- RISC-V (RV64) support, alongside i386, amd64, aarch64 and arm (#420, #421,
+  #422, #423, #425). Every gadget the riscv64 fixture reports has been run under
+  a debugger and seen to spawn a real shell, the same bar the other
+  architectures are held to (#424).
+
 ## v2.0.0 - 2026-08-29
 
 Reported gadgets are not offset-for-offset comparable with 1.x: constraints are

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Note: requires ruby version >= 2.1.0, you can use `ruby --version` to check.
 - [x] amd64 (x86-64)
 - [x] aarch64 (ARMv8)
 - [x] arm (ARMv7, A32/Thumb-2)
+- [x] riscv64 (RV64GC)
 
 ## Implementation
 
@@ -570,6 +571,32 @@ $ one_gadget spec/data/arm-libc-2.39.so
 #   [r3] == NULL || r3 == NULL || r3 is a valid envp
 #   [sp+0x34] == NULL || writable: [sp+0x34]
 #   [sp+0x2c] == NULL || (s32)[[sp+0x2c]+0x4] <= 0x0
+
+```
+
+##### RISC-V (RV64)
+
+```bash
+$ one_gadget spec/data/riscv64-libc-2.39.so
+# 0x9f73a execve("/bin/sh", s1, a2)
+# constraints:
+#   [s1] == NULL || s1 == NULL || s1 is a valid argv
+#   [a2] == NULL || a2 == NULL || a2 is a valid envp
+#
+# 0x9f73c execve("/bin/sh", a1, a2)
+# constraints:
+#   [a1] == NULL || a1 == NULL || a1 is a valid argv
+#   [a2] == NULL || a2 == NULL || a2 is a valid envp
+#
+# 0x9f778 execve("/bin/sh", s1, s2)
+# constraints:
+#   [s1] == NULL || s1 == NULL || s1 is a valid argv
+#   [s2] == NULL || s2 == NULL || s2 is a valid envp
+#
+# 0xb5adc posix_spawn(sp+0x44, "/bin/sh", [sp+0x30], 0, sp+0x50, environ)
+# constraints:
+#   [sp+0x50] == NULL || {[sp+0x50], [sp+0x58], [sp+0x60], [sp+0x68], ...} is a valid argv
+#   [sp+0x30] == NULL || (s32)[[sp+0x30]+0x4] <= 0x0
 
 ```
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -33,6 +33,7 @@ Note: requires ruby version >= 2.1.0, you can use `ruby --version` to check.
 - [x] amd64 (x86-64)
 - [x] aarch64 (ARMv8)
 - [x] arm (ARMv7, A32/Thumb-2)
+- [x] riscv64 (RV64GC)
 
 ## Implementation
 
@@ -157,6 +158,12 @@ SHELL_OUTPUT_OF(one_gadget spec/data/aarch64-libc-2.27.so)
 
 ```bash
 SHELL_OUTPUT_OF(one_gadget spec/data/arm-libc-2.39.so)
+```
+
+##### RISC-V (RV64)
+
+```bash
+SHELL_OUTPUT_OF(one_gadget spec/data/riscv64-libc-2.39.so)
 ```
 
 #### Combine with Script

--- a/docs/adding-an-architecture.md
+++ b/docs/adding-an-architecture.md
@@ -111,7 +111,7 @@ Reading the flow:
 
 The last three have defaults in `Base` that read the `$base`-relative form an arch
 produces once it concretizes a pc-relative operand, so an arch that renders
-addresses that way (aarch64, arm, amd64) implements none of them. Override
+addresses that way (aarch64, arm, amd64, riscv64) implements none of them. Override
 them only where the address reads differently — i386 reaches a global through its
 GOT register, so all three are its own.
 | `branch_kind(line)` | classify an instruction: `:conditional`, `:unconditional`, `:terminator`, or `nil` (not a branch) |


### PR DESCRIPTION
The README's architecture list and an example of what the arch actually reports, through the template the README is generated from rather than the README itself. The changelog entry says what a reader of it wants to know: the support is there, and every gadget the fixture reports has been run under a debugger and seen to spawn a real shell, which is the bar the other architectures are held to.

Held back until now deliberately -- claiming the architecture before its loads, stores and branches existed would have overstated what a user would get.