### PR TITLE
Fail the build on a doc comment that lost its definition

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,6 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
-require 'yard'
 
 import 'tasks/aletheia.rake'
 import 'tasks/builds/audit.rake'
@@ -11,9 +10,10 @@ import 'tasks/builds/check.rake'
 import 'tasks/builds/generate.rake'
 import 'tasks/builds/list.rake'
 import 'tasks/builds/refresh.rake'
+import 'tasks/doc.rake'
 import 'tasks/readme.rake'
 
-task default: %i[readme rubocop spec builds:list builds:audit builds:check]
+task default: %i[readme rubocop doc doc:orphans spec builds:list builds:audit builds:check]
 
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.patterns = ['lib/**/*.rb', 'spec/**/*.rb', 'bin/*', 'tasks/**/*.rake', 'aletheia/**/*.rb', 'aletheia/bin/*']
@@ -24,9 +24,4 @@ RSpec::Core::RakeTask.new(:spec) do |task|
   # The harness's own unit specs run with the suite; +.rspec+ says the same for a
   # bare +rspec+, which this task does not read.
   task.pattern = '{spec,aletheia/spec}/**/*_spec.rb'
-end
-
-YARD::Rake::YardocTask.new(:doc) do |t|
-  t.files = Dir['lib/**/*.rb'] - Dir['lib/one_gadget/builds/*.rb']
-  t.stats_options = ['--list-undoc']
 end

--- a/lib/one_gadget/emulators/arm.rb
+++ b/lib/one_gadget/emulators/arm.rb
@@ -133,12 +133,6 @@ module OneGadget
         @prev_addr = @cur_addr
       end
 
-      # Split an objdump line into its instruction body and the literal-pool address
-      # embedded in the trailing +@+ comment (used by PC-relative +ldr+).
-      # @return [(String, Integer?)] The instruction body, and the literal address (or +nil+).
-      # @example
-      #   split_line('2c626: ldr r2, [pc, #128] @ (2c6a8 <x>)')
-      #   #=> ['ldr r2, [pc, #128]', 0x2c6a8]
       # The instruction body a line carries, in the plain form the generic parser
       # expects, and the literal-pool address it points at. Both are decided by the
       # text alone (see {Processor.line_memo}).
@@ -151,6 +145,12 @@ module OneGadget
         end
       end
 
+      # Split an objdump line into its instruction body and the literal-pool address
+      # embedded in the trailing +@+ comment (used by PC-relative +ldr+).
+      # @return [(String, Integer?)] The instruction body, and the literal address (or +nil+).
+      # @example
+      #   split_line('2c626: ldr r2, [pc, #128] @ (2c6a8 <x>)')
+      #   #=> ['ldr r2, [pc, #128]', 0x2c6a8]
       def split_line(line)
         body = line.sub(/\A[0-9a-f]+:\s*/, '')
         literal = body[/@\s*\(?([0-9a-f]+)\s/, 1]&.to_i(16)

--- a/lib/one_gadget/emulators/constraints.rb
+++ b/lib/one_gadget/emulators/constraints.rb
@@ -12,7 +12,7 @@ module OneGadget
     # implies and names what is left. Mixed into {Processor}.
     module Constraints
       # Marks a register holding whatever a call returned or left behind; see
-      # {#clobber_caller_saved}.
+      # {Processor#clobber_caller_saved}.
       CLOBBERED = '$clobbered'
 
       # Constraint types whose payload is an address {Lambda} asserting the target

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -71,7 +71,7 @@ module OneGadget
 
       # Record a reached terminal +exec*+ call as the gadget's effect and stop
       # emulating: it is the gadget's goal, and any following instruction would
-      # clobber the argument registers that {#resolve} reads to describe it.
+      # clobber the argument registers that {OneGadget::Fetchers::ArgumentResolution#resolve} reads to describe it.
       # @param [String] addr The call target.
       # @return [Symbol] +:fail+, the sentinel {#process!} maps to "stop".
       def reach_terminal_call(addr)

--- a/lib/one_gadget/emulators/tracked_memory.rb
+++ b/lib/one_gadget/emulators/tracked_memory.rb
@@ -13,7 +13,7 @@ module OneGadget
       # @return [Hash{Integer => OneGadget::Emulators::Lambda}] Memory written through +sp+.
       def sp_based_stack = get_corresponding_stack(sp)
 
-      # @return [Hash{Integer => Lambda}, nil] Memory written through {#bp}, or nil when the arch has none.
+      # @return [Hash{Integer => Lambda}, nil] Memory written through {Processor#bp}, or nil when the arch has none.
       def bp_based_stack = bp && get_corresponding_stack(bp)
 
       # Enable frame-pointer stack tracking with +bp+ as the frame register, so a
@@ -111,7 +111,7 @@ module OneGadget
       end
 
       # An always-on tracked stack keyed by offset: a Hash that lazily materialises
-      # +[reg+off]+ as a one-deref {Lambda}. Used for the +sp+- and {#bp}-based stacks.
+      # +[reg+off]+ as a one-deref {Lambda}. Used for the +sp+- and {Processor#bp}-based stacks.
       def tracked_stack(reg)
         Hash.new do |h, k|
           h[k] = OneGadget::Emulators::Lambda.new(reg).tap do |lmda|
@@ -201,7 +201,7 @@ module OneGadget
         add_writable(dst_l) unless stack.equal?(sp_based_stack)
       end
 
-      # Resolve +sp+- and (when tracked) {#bp}-relative operands to their offset.
+      # Resolve +sp+- and (when tracked) {Processor#bp}-relative operands to their offset.
       def eval_dict
         bp ? { sp => 0, bp => 0 } : { sp => 0 }
       end

--- a/tasks/builds/generate.rake
+++ b/tasks/builds/generate.rake
@@ -54,8 +54,6 @@ namespace :builds do
     TEMPLATE.sub('INFO', info_str).sub('GADGETS', gadgets_str)
   end
 
-  # @param [String] filename Path of the libc to read.
-  # @param [String] source Where that libc came from, recorded as the build file's first line.
   # One +Gadget.add+ call. A gadget names the descriptors it closes only when it
   # closes any, so an entry says no more than it has to.
   def gadget_entry(gadget)

--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'yard'
+
+# What YARD is asked about: the library, minus the generated build files.
+DOCUMENTED_FILES = Dir['lib/**/*.rb'] - Dir['lib/one_gadget/builds/*.rb']
+
+# Everywhere a doc comment is written, which is more than YARD is pointed at.
+COMMENTED_FILES = (DOCUMENTED_FILES + Dir['{spec,aletheia}/**/*.rb'] + Dir['tasks/**/*.rake'] +
+                   Dir['{bin,aletheia/bin}/*']).sort
+
+# A tag opens at the base indent; its description continues indented under it.
+TAG_LINE = /\A#\s@\S/
+CONTINUATION_LINE = /\A#\s\s/
+SUMMARY_LINE = /\A#\s\S/
+
+YARD::Rake::YardocTask.new(:doc) do |t|
+  t.files = DOCUMENTED_FILES
+  t.options = ['--fail-on-warning']
+  t.stats_options = ['--list-undoc']
+end
+
+namespace :doc do
+  desc 'Check that every doc comment describes the definition below it'
+  task :orphans do
+    strays = COMMENTED_FILES.flat_map do |path|
+      orphaned_doc(path).map { |lineno, text| "#{path}:#{lineno}: #{text}" }
+    end
+    next if strays.empty?
+
+    abort(<<~MESSAGE)
+      A doc comment describes the definition below it, and these have run together with the one after
+      them -- YARD gives the pair to whichever definition follows and the other's is silently lost:
+      #{strays.join("\n")}
+    MESSAGE
+  end
+end
+
+# Where a comment block starts describing something else. Two blocks separated by
+# nothing are one block to YARD, so the definition the first was written for ends
+# up undocumented; the tell is a summary line following a tag, since a tag's own
+# description continues indented.
+# @param [String] path
+# @return [Array<(Integer, String)>] The line number and text of each block's first stray summary.
+def orphaned_doc(path)
+  strays = []
+  block = []
+  File.readlines(path).each_with_index do |line, index|
+    text = line.strip
+    if text.start_with?('#')
+      block << [index + 1, text]
+    else
+      strays << stray_summary(block) unless text.empty?
+      block = []
+    end
+  end
+  strays.compact
+end
+
+# The first line of +block+ that starts describing something the lines before it
+# have already tagged.
+# @param [Array<(Integer, String)>] block
+# @return [(Integer, String), nil]
+def stray_summary(block)
+  tagged = false
+  block.each do |lineno, text|
+    next if CONTINUATION_LINE.match?(text)
+
+    if TAG_LINE.match?(text) then tagged = true
+    elsif tagged && SUMMARY_LINE.match?(text) then return [lineno, text]
+    end
+  end
+  nil
+end


### PR DESCRIPTION
A doc block written above a definition follows whatever text sits below it: write a new method between the two and YARD hands the fused pair to that method, dropping the original's description without a word. Two such blocks were already in the tree, and the one that turned up in review was caught only because both halves happened to name the same @param.

rake now runs doc (with --fail-on-warning, so an unresolvable link or a duplicate tag is an error) and doc:orphans, which reads every commented file for a summary line following a tag -- the shape a fused block always has, and the one YARD is silent about.