### PR TITLE
Say each thing where it belongs, once

### DIFF
--- a/lib/one_gadget/emulators/conditional.rb
+++ b/lib/one_gadget/emulators/conditional.rb
@@ -11,10 +11,6 @@ module OneGadget
     # actual taken/not-taken path (see {OneGadget::Fetchers::Base#candidates}), and
     # the emulator turns the branch decision into a gadget constraint.
     #
-    # Branches are resolved with one line of look-ahead: at the branch we record a
-    # pending decision, and on the next line we compare that line's address to the
-    # branch target to learn whether the stitched path took the branch.
-    #
     # The including class (an {OneGadget::Emulators::Processor} subclass) must
     # provide +registers+ and +register?+ (operand lookup), +operands(cmd)+ (the
     # arch's operand splitter), +self.class.bits+ (32/64, for the signedness cast),

--- a/lib/one_gadget/emulators/processor.rb
+++ b/lib/one_gadget/emulators/processor.rb
@@ -183,37 +183,12 @@ module OneGadget
         end
       end
 
-      # Accept a +call+ to a libc function the emulator treats as non-terminal
-      # (a syscall wrapper). {SafeCalls::COMMON} maps each function name to its
-      # per-argument requirements: an argument index paired with one of
-      # * +:global_var?+ - a precondition that must already hold, else the
-      #   candidate is aborted (+:fail+).
-      # * +:closed_fd+ - the descriptor the callee closes. Nothing is required of
-      #   it; it is recorded, because closing a standard descriptor changes what
-      #   the spawned shell can still do (see {#note_closed_fd}).
-      # * +:null+ - the callee must be given NULL here, so +<arg> == NULL+ is
-      #   recorded for the caller to arrange. A value that can never be NULL --
-      #   a fixed address, or any other non-zero literal -- aborts the candidate.
-      #   @example +__sigaction(sig, act, oldact)+ writes the old action through
-      #     +oldact+ unless it is NULL
-      # * +:nullable_deref+ - the callee dereferences this argument *unless it is
-      #   NULL*, which glibc guards with an explicit NULL check. When the pointer
-      #   isn't already known to be mapped, +<arg> == NULL+ is recorded so the
-      #   callee takes the skip-the-dereference path. Only tag an argument this way
-      #   after confirming the callee both NULL-checks it and still reaches the
-      #   terminal call on the NULL path.
-      # * +:deref+ - the callee dereferences this argument *unconditionally* (no
-      #   NULL guard), so it can't be made safe by forcing it NULL. When the pointer
-      #   isn't already known to be mapped, +readable: <arg>+ is recorded so the
-      #   attacker knows it must reference readable memory.
-      #   @example +posix_spawnattr_setsigmask(attr, set)+ runs +attr->__ss = *set+
-      # * +:writable+ - the callee *writes through* this argument (an out-param), so
-      #   +writable: <arg>+ is recorded (via {#add_writable}, which drops the
-      #   pc/+$base+/sp targets that are writable or fixed for free).
-      #   @example +posix_spawnattr_init(attr)+ writes +*attr+
-      # Both deref checks are deferred to {#finalize_deferred_reads} because a
-      # +<reg>+<imm>+ pointer may only become known-mapped once a later store marks
-      # +<reg>+ writable.
+      # Accept a +call+ to a libc function the emulator treats as non-terminal (a
+      # syscall wrapper), applying whatever {SafeCalls::COMMON} records about its
+      # arguments. Both deref requirements are deferred to
+      # {#finalize_deferred_reads}, because a +<reg>+<imm>+ pointer may only become
+      # known-mapped once a later store marks +<reg>+ writable.
+      # @param [String] addr The call target, as objdump names it.
       # @return [nil, :fail] +nil+ = call accepted, +:fail+ = abort the candidate.
       def dispatch_safe_call(addr)
         func = SafeCalls::COMMON.keys.find { |n| addr.include?(n) }
@@ -239,12 +214,6 @@ module OneGadget
       # accepted on the basis that they succeed, and success is what they all
       # report that way, so a branch on the result resolves instead of ending the
       # path. A path that needs the failing side then contradicts itself and drops.
-      #
-      # TODO: success is assumed, not required. A path that keeps going after the
-      # call fails can reach a terminal call just as well, and is dropped here
-      # only because the return is pinned. Modelling the result per function --
-      # which values it can return, and what each one requires -- would let both
-      # sides be walked, at the cost of a constraint describing the failing one.
       # @return [void]
       def clobber_caller_saved
         caller_saved.each do |reg|

--- a/lib/one_gadget/emulators/safe_calls.rb
+++ b/lib/one_gadget/emulators/safe_calls.rb
@@ -3,9 +3,9 @@
 module OneGadget
   module Emulators
     # Arch-independent catalog of libc calls the emulator accepts without
-    # executing them (see {Processor#dispatch_safe_call} for how an entry's
-    # per-argument requirements are applied and what each requirement symbol
-    # means). These functions -- syscall wrappers and +posix_spawn+'s setup
+    # executing them (see {COMMON} for what each requirement means, and
+    # {Processor#dispatch_safe_call} for how they are applied). These
+    # functions -- syscall wrappers and +posix_spawn+'s setup
     # helpers -- have identical semantics on every architecture, so their
     # requirements live here once instead of being copied into each arch's
     # emulator, keeping the arches from drifting.
@@ -14,6 +14,16 @@ module OneGadget
     # the specific +posix_spawnattr_setsigmask+/+setsigdefault+ keys precede the
     # generic +posix_spawnattr_+ prefix.
     module SafeCalls
+      # What each requirement asks of the caller, the entries below saying why the
+      # function needs it:
+      # * +:global_var?+ -- nothing; it must already hold, or the candidate is aborted.
+      # * +:closed_fd+ -- nothing; the descriptor is recorded (see {Processor#note_closed_fd}).
+      # * +:null+, +:nullable_deref+ -- +<arg> == NULL+, because the callee writes through
+      #   it otherwise, or dereferences it unless it is NULL. Tag the second only after
+      #   confirming the callee both NULL-checks the argument and still reaches the
+      #   terminal call on that path.
+      # * +:deref+ -- +readable: <arg>+, for a pointer NULL cannot make safe.
+      # * +:writable+ -- +writable: <arg>+.
       # @return [Hash{String => Hash{Integer => Symbol}}]
       #   Function name (or name prefix) => argument index => requirement.
       COMMON = {

--- a/lib/one_gadget/fetchers/disassembly.rb
+++ b/lib/one_gadget/fetchers/disassembly.rb
@@ -28,10 +28,6 @@ module OneGadget
       # How much to disassemble around each terminal call when an architecture can
       # locate the calls cheaply (see {#terminal_call_sites} / {#windowed_disasm}).
       #
-      # The walk runs backwards from the call, but what it reaches does not: a
-      # branch predecessor can sit *after* the call, so the window has to hold the
-      # loop or later block that jumps back into the region.
-      #
       # Both directions were measured by windowing every architecture against its
       # own full disassembly across the spec corpus. Gadgets start being lost below
       # 0x400 either way, and a window too small to hold a predecessor invents them
@@ -40,10 +36,7 @@ module OneGadget
       # a fifth of a libc -- terminal calls cluster into a handful of merged
       # windows, so a wider one costs little.
       #
-      # A gadget whose code and branch-predecessors exceed the window is missed,
-      # which is why windowing is opt-in per arch (fast disassembly arches keep the
-      # full, exhaustive scan) and falls back to full disassembly if the call scan
-      # comes up empty.
+      # A gadget whose code and branch-predecessors exceed the window is missed.
       WINDOW_BACK = 0x4000
 
       # As far past the call, for a predecessor that branches back into the region.

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -10,6 +10,23 @@ module OneGadget
   # Module for define gadgets.
   module Gadget
     # Information of a gadget.
+    #
+    # Its {Gadget#constraints} are written in this language:
+    #   REG: OneGadget::ABI.all
+    #   IMM: [+-]0x[\da-f]+
+    #   BITS: 8, 16, 32, 64
+    #   CAST: (<s|u><BITS>)
+    #   Identity: <REG><IMM>?
+    #   Identity: [<Identity>]
+    #   Expr: <REG> is the GOT address of libc
+    #   Expr: writable: <Identity>
+    #   Expr: readable: <Identity>
+    #   Expr: <CAST>?<Identity> == NULL
+    #   Expr: <REG> & 0xf == <IMM>
+    #   Expr: (s32)[<Identity>] <= 0
+    #   Expr: .+ is a valid argv
+    #   Expr: .+ is a valid envp
+    #   Expr: <Expr> || <Expr>
     class Gadget
       # @return [Integer] Base address of libc. Default: 0.
       attr_accessor :base
@@ -138,22 +155,12 @@ module OneGadget
       private
 
       # Drops what the rest of the list already settles, so a gadget asks for each
-      # thing once and never offers an option it rules out itself.
-      #
-      # Most of it follows from one reading: a constraint that accesses an address
-      # says that address is mapped memory (see {#mapped?}), which in turn says it
-      # is readable and not NULL. So:
-      # * A +readable:+ on an address a dereference already reaches repeats it.
-      # * A +== NULL+ option for a mapped address can never be taken.
-      # * A +!= NULL+ requirement on one is already met.
-      # The last rule reads a value rather than an address: one the list pins to a
-      # literal answers every other comparison against it, so a bound that literal
-      # already satisfies asks for nothing.
-      #
-      # Each needs the constraint doing the settling to hold outright: one inside a
-      # +||+ is an option among several and settles nothing. They run until the
-      # list stops changing, because dropping an option can leave a constraint
-      # holding outright and settle the next thing.
+      # thing once and never offers an option it rules out itself. Three of the
+      # rules follow from one reading -- a constraint that accesses an address says
+      # that address is mapped memory (see {#mapped?}), and so readable and not
+      # NULL -- while the fourth reads a value the list pins to a literal. Only a
+      # constraint holding outright settles anything, since one inside a +||+ is an
+      # option among several, and they run until the list stops changing.
       # @param [Array<String>] cons
       # @return [Array<String>]
       # @example An option the same list rules out.
@@ -305,21 +312,6 @@ module OneGadget
         end
       end
 
-      # REG: OneGadget::ABI.all
-      # IMM: [+-]0x[\da-f]+
-      # BITS: 8, 16, 32, 64
-      # CAST: (<s|u><BITS>)
-      # Identity: <REG><IMM>?
-      # Identity: [<Identity>]
-      # Expr: <REG> is the GOT address of libc
-      # Expr: writable: <Identity>
-      # Expr: readable: <Identity>
-      # Expr: <CAST>?<Identity> == NULL
-      # Expr: <REG> & 0xf == <IMM>
-      # Expr: (s32)[<Identity>] <= 0
-      # Expr: .+ is a valid argv
-      # Expr: .+ is a valid envp
-      # Expr: <Expr> || <Expr>
       def calculate_score(expr)
         return expr.split(' || ').map(&method(:calculate_score)).max if expr.include?(' || ')
 


### PR DESCRIPTION
Nothing in lib now carries more than three paragraphs of prose.

dispatch_safe_call spent 31 lines defining SafeCalls' requirement vocabulary -- what :deref and :nullable_deref and the rest mean. That is what SafeCalls::COMMON records, so it is documented there, and the method says what it does with an entry. Three @example tags in it were nested inside bullets, where YARD does not read them as tags at all: it parsed zero examples and rendered them as literal "@example ..." text. They are prose now, which is what they always were.

calculate_score carried the grammar of the constraint language on a private scorer. The class emits those strings, so the class states the grammar.

prune_settled enumerated four rules and then demonstrated all four in @examples. The examples stay and the enumeration goes.

Conditional described the one-line look-ahead that resolve_pending_branch documents in full, and WINDOW_BACK explained the forward reach that WINDOW_FWD states in one line, plus a fallback stated where it happens.

clobber_caller_saved's TODO -- that an accepted call is assumed to succeed rather than required to -- is a design proposal, not a description. It is in the work queue.