### PR TITLE
Fail the build on a public method that hides its signature

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ import 'tasks/builds/refresh.rake'
 import 'tasks/doc.rake'
 import 'tasks/readme.rake'
 
-task default: %i[readme rubocop doc doc:orphans spec builds:list builds:audit builds:check]
+task default: %i[readme rubocop doc doc:orphans doc:untagged spec builds:list builds:audit builds:check]
 
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.patterns = ['lib/**/*.rb', 'spec/**/*.rb', 'bin/*', 'tasks/**/*.rake', 'aletheia/**/*.rb', 'aletheia/bin/*']

--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -34,6 +34,49 @@ namespace :doc do
       #{strays.join("\n")}
     MESSAGE
   end
+
+  desc 'Check that every public method says what it takes and what it gives back'
+  task :untagged do
+    YARD::Registry.clear
+    YARD.parse(DOCUMENTED_FILES, [], YARD::Logger::ERROR)
+    undocumented = YARD::Registry.all(:method).sort_by(&:path).filter_map do |method|
+      next unless method.visibility == :public
+      # An attribute is documented once, by the @return on the reader; its writer
+      # takes exactly that value back.
+      next if method.is_attribute?
+
+      missing = undocumented_signature(method)
+      "#{method.file}:#{method.line}: #{method.path} -- #{missing.join(', ')}" unless missing.empty?
+    end
+    next if undocumented.empty?
+
+    abort(<<~MESSAGE)
+      A public method states each parameter it takes and what it returns; these do not:
+      #{undocumented.join("\n")}
+    MESSAGE
+  end
+end
+
+# What +method+ leaves unsaid about its own signature.
+# @param [YARD::CodeObjects::MethodObject] method
+# @return [Array<String>] The missing tags, written as they would be.
+def undocumented_signature(method)
+  documented = method.tags(:param).map { |tag| tag.name.to_s }
+  missing = parameter_names(method).reject { |name| documented.include?(name) }.map { |name| "@param #{name}" }
+  missing << '@return' if method.tags(:return).empty? && method.tags(:overload).empty?
+  missing
+end
+
+# The parameters +method+ takes, named as a +@param+ names them: without the
+# keyword's colon or a splat's stars, and without the block, which +@yield+
+# tags describe instead.
+# @param [YARD::CodeObjects::MethodObject] method
+# @return [Array<String>]
+def parameter_names(method)
+  method.parameters.filter_map do |name, _default|
+    name = name.to_s.delete_suffix(':').sub(/\A\*+/, '')
+    name unless name.empty? || name.start_with?('&')
+  end
 end
 
 # Where a comment block starts describing something else. Two blocks separated by


### PR DESCRIPTION
#436 gave every public method a @param for each parameter and a @return. Nothing kept it that way: a new architecture arrives with a dozen inst_* overrides, and the next one to land bare would land unnoticed.

doc:untagged reads the same registry `doc` builds and names what a method leaves unsaid. Two things it deliberately does not report: an attribute, which is documented once by the @return on its reader, and a block, which @yield tags describe. A keyword or splat parameter is named as a @param names it, without the colon or the stars, or every method taking **options would read as undocumented.

YARD supplies some of these itself -- a @return [Boolean] for a predicate, a constructor's return -- and the check takes them as given rather than asking for what a reader already sees.