### PR TITLE
Ask objdump once, build the call pattern once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ releases are cut by giving that section a version and a date.
   plus the libcs the specs run against, and 2.26 is neither of those any more; a
   lookup by one of those BuildIDs now answers from the remote database. The
   entries themselves stay in the repository, as every unshipped build does.
+- A search no longer asks objdump which targets it supports once per command it
+  builds, nor rebuilds the pattern naming a call mnemonic for every line it
+  reads. Roughly a tenth off a search (aarch64 glibc 2.43: 0.53s to 0.47s).
 - Searching a MIPS libc now reads only the code around its calls, rather than
   disassembling the whole file: 1.9s to 0.7s for the mipsel glibc fixture and
   2.3s to 0.7s for the musl ones. The gadgets reported are unchanged.

--- a/lib/one_gadget/fetchers/base.rb
+++ b/lib/one_gadget/fetchers/base.rb
@@ -160,7 +160,14 @@ module OneGadget
       #   call_line?('e6570: call   94180 <execve>')          #=> true
       #   call_line?('a34d0: b      a3210 <execlp+0x1a8>')    #=> false
       def call_line?(line)
-        line[/\A\s*[0-9a-f]+:\s*(\S+)/, 1]&.match?(/\A#{call_str}x?(?:\.[wn])?\z/) || false
+        line[/\A\s*[0-9a-f]+:\s*(\S+)/, 1]&.match?(call_mnemonic) || false
+      end
+
+      # The mnemonics {#call_str} names, as the whole of one. Built once: it comes
+      # out of a constant, and a search asks it of every line of a libc.
+      # @return [Regexp]
+      def call_mnemonic
+        @call_mnemonic ||= /\A#{call_str}x?(?:\.[wn])?\z/
       end
 
       # Whether +line+ transfers control, so the address it names is a place in

--- a/lib/one_gadget/helper.rb
+++ b/lib/one_gadget/helper.rb
@@ -304,8 +304,16 @@ module OneGadget
     def objdump_arch_supported?(bin, arch)
       return false if bin.nil?
 
-      arch = objdump_arch(arch)
-      `#{::Shellwords.join([bin, '--help'])}`.lines.any? { |c| c.split.include?(arch) }
+      objdump_targets(bin).include?(objdump_arch(arch))
+    end
+
+    # The target names an objdump binary lists as supported. Asked of the binary
+    # once: the answer is a property of that build, while the question is asked
+    # again for every command a search assembles.
+    # @param [String] bin Path to the objdump binary.
+    # @return [Array<String>]
+    def objdump_targets(bin)
+      (@objdump_targets ||= {})[bin] ||= `#{::Shellwords.join([bin, '--help'])}`.split
     end
 
     # Converts to the architecture name shown in objdump's +--help+ command.


### PR DESCRIPTION
Profiling the suite found two answers recomputed rather than kept: which targets an objdump binary supports, asked with a subprocess for every command a search assembles (307 of them across the specs), and the regexp naming a call mnemonic, rebuilt from a constant string for every disassembled line.