### PR TITLE
Ask a symbol what it records, not the structure it is recorded in

### DIFF
--- a/lib/one_gadget/fetchers/arm.rb
+++ b/lib/one_gadget/fetchers/arm.rb
@@ -33,8 +33,8 @@ module OneGadget
       # @return [void]
       def record_instruction_sets(elf)
         entries = elf.dynamic.symbols.filter_map do |symbol|
-          value = symbol.header.st_value.to_i
-          next if value.zero? || (symbol.header.st_info.to_i & 0xf) != ELFTools::Constants::STT_FUNC
+          value = symbol.value
+          next if value.zero? || symbol.type != ELFTools::Constants::STT_FUNC
 
           [symbol_address(value), value.odd?]
         end

--- a/lib/one_gadget/fetchers/dynamic_symbols.rb
+++ b/lib/one_gadget/fetchers/dynamic_symbols.rb
@@ -59,7 +59,7 @@ module OneGadget
       # @return [Hash{Integer => String}]
       def dynamic_symbols(elf)
         @dynamic_symbols ||= (elf.dynamic&.symbols || []).each_with_object({}) do |symbol, symbols|
-          value = symbol.header.st_value.to_i
+          value = symbol.value
           name = symbol.name.to_s
           next if value.zero? || name.empty?
 

--- a/lib/one_gadget/fetchers/mips.rb
+++ b/lib/one_gadget/fetchers/mips.rb
@@ -395,7 +395,7 @@ module OneGadget
 
         # Read out of the symbols now, rather than holding them: they are lazy, and
         # the file they would read from is closed as soon as this returns.
-        symbols = dynamic.symbols.map { |symbol| [symbol.header.st_value.to_i, symbol.name] }
+        symbols = dynamic.symbols.map { |symbol| [symbol.value, symbol.name] }
         names = symbols.to_h { |value, name| [value, name] }
                        .reject { |value, name| value.zero? || name.empty? }
         { local:, gotsym:, symbols:, names:, big: elf.endian == :big,

--- a/spec/fetchers/dynamic_symbols_spec.rb
+++ b/spec/fetchers/dynamic_symbols_spec.rb
@@ -18,7 +18,7 @@ describe OneGadget::Fetchers::DynamicSymbols do
       with_elf do |elf|
         symbols = fetcher.send(:dynamic_symbols, elf)
         execve = elf.section_by_name('.dynsym').symbol_by_name('execve')
-        expect(symbols[execve.header.st_value.to_i]).to eq 'execve'
+        expect(symbols[execve.value]).to eq 'execve'
         expect(symbols.values).to include('posix_spawn')
       end
     end
@@ -29,7 +29,7 @@ describe OneGadget::Fetchers::DynamicSymbols do
       versioned = data_path('aarch64-libc-2.27.so')
       File.open(versioned) do |fd|
         elf = ELFTools::ELFFile.new(fd)
-        addr = elf.section_by_name('.dynsym').symbol_by_name('sigaction').header.st_value.to_i
+        addr = elf.section_by_name('.dynsym').symbol_by_name('sigaction').value
         expect(OneGadget::Fetchers::AArch64.new(versioned).send(:dynamic_symbols, elf)[addr])
           .to eq '__sigaction'
       end


### PR DESCRIPTION
Reading a symbol through its header is what forces a structure to be built for it, which is most of the cost of reading a symbol table: on libc-2.31 that is 203 objects per symbol, and one_gadget reads every symbol of a libc that has been stripped of its sections.

The accessors say the same thing today and, with the lazy read pending in elftools, say it without building anything -- the spec suite goes 17.0s to 12.6s once that lands, against 16.3s for the same elftools reached through the header.