### PR TITLE
Report the gadgets a walk was throwing away when it ran out of budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ releases are cut by giving that section a version and a date.
 
 ### Fixed
 
+- A backward walk that ran out of its path budget threw away everything it had
+  walked (#460), where one that runs out of predecessors reports it. Which gadgets
+  a libc yields therefore depended on how far back it happened to be disassembled.
+  67 more across the fixtures, every one of them run under a debugger and seen to
+  spawn a real shell.
+- MIPS: no gadget is reported for a window that calls a function which builds its
+  own GOT base without having put that function's address in `t9` (#460), which
+  o32 asks of a caller. The call arrives; what the callee then computes is wrong,
+  and six such gadgets were verified not to work.
+
 - arm found nothing at all in a libc with no section headers (#441). Three
   things were in the way: objdump has no mapping symbols to switch instruction
   set on, so it read Thumb code as A32 -- each stretch is now disassembled as

--- a/README.md
+++ b/README.md
@@ -609,10 +609,29 @@ router's libc usually arrives in.
 
 ```bash
 $ one_gadget spec/data/mips-musl-1.2.4.so
-# 0x56fd4 execl("/bin/sh", a1-0x7c70)
+# 0x668e8 posix_spawn(sp+0x20, "/bin/sh", 0, s0, sp+0x28, environ)
 # constraints:
 #   gp is the GOT address of libc
-#   a1-0x7c70 == NULL
+#   {"sh", "-c", s1, NULL} is a valid argv
+#   s0 == NULL || (u16)[s0] == 0x0
+#
+# 0x668ec posix_spawn(sp+0x20, "/bin/sh", 0, s0, sp+0x28, environ)
+# constraints:
+#   gp is the GOT address of libc
+#   {"sh", "-c", [sp+0x30], NULL} is a valid argv
+#   s0 == NULL || (u16)[s0] == 0x0
+#
+# 0x668f0 posix_spawn(sp+0x20, "/bin/sh", 0, a3, sp+0x28, environ)
+# constraints:
+#   gp is the GOT address of libc
+#   {"sh", "-c", [sp+0x30], NULL} is a valid argv
+#   a3 == NULL || (u16)[a3] == 0x0
+#
+# 0x668f4 posix_spawn(sp+0x20, "/bin/sh", 0, a3, sp+0x28, environ)
+# constraints:
+#   gp is the GOT address of libc
+#   v0-0x7c70 == NULL || {v0-0x7c70, "-c", [sp+0x30], NULL} is a valid argv
+#   a3 == NULL || (u16)[a3] == 0x0
 #
 # 0x77b44 posix_spawn(sp+0x20, "/bin/sh", s2, 0, sp+0x2c, environ)
 # constraints:

--- a/lib/one_gadget/builds/libc-2.43-b50ceafbd17dc6bceee344a66671c7eaa152bef4.rb
+++ b/lib/one_gadget/builds/libc-2.43-b50ceafbd17dc6bceee344a66671c7eaa152bef4.rb
@@ -16,13 +16,28 @@ require 'one_gadget/gadget'
 
 build_id = File.basename(__FILE__, '.rb').split('-').last
 OneGadget::Gadget.add(build_id, 310192,
+                      constraints: ["readable: x22", "x0 != 0x1", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],
+                      effect: "posix_spawn(sp+0xc, \"/bin/sh\", 0, sp+0x218, sp+0x50, environ)")
+OneGadget::Gadget.add(build_id, 310192,
                       constraints: ["readable: x22", "x0 == 0x1", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],
+                      effect: "posix_spawn(sp+0xc, \"/bin/sh\", 0, sp+0x218, sp+0x50, environ)")
+OneGadget::Gadget.add(build_id, 310196,
+                      constraints: ["readable: x22", "x0 != 0x1", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],
                       effect: "posix_spawn(sp+0xc, \"/bin/sh\", 0, sp+0x218, sp+0x50, environ)")
 OneGadget::Gadget.add(build_id, 310196,
                       constraints: ["readable: x22", "x0 == 0x1", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],
                       effect: "posix_spawn(sp+0xc, \"/bin/sh\", 0, sp+0x218, sp+0x50, environ)")
 OneGadget::Gadget.add(build_id, 310200,
+                      constraints: ["readable: x22", "x0 != 0x1", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],
+                      effect: "posix_spawn(sp+0xc, \"/bin/sh\", 0, sp+0x218, sp+0x50, environ)")
+OneGadget::Gadget.add(build_id, 310200,
                       constraints: ["readable: x22", "x0 == 0x1", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],
+                      effect: "posix_spawn(sp+0xc, \"/bin/sh\", 0, sp+0x218, sp+0x50, environ)")
+OneGadget::Gadget.add(build_id, 310208,
+                      constraints: ["readable: x22", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],
+                      effect: "posix_spawn(sp+0xc, \"/bin/sh\", 0, sp+0x218, sp+0x50, environ)")
+OneGadget::Gadget.add(build_id, 310212,
+                      constraints: ["readable: x22", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],
                       effect: "posix_spawn(sp+0xc, \"/bin/sh\", 0, sp+0x218, sp+0x50, environ)")
 OneGadget::Gadget.add(build_id, 310216,
                       constraints: ["readable: x22", "{\"sh\", \"-c\", \"--\", x21, ...} is a valid argv", "sp+0x218 == NULL || (u16)[sp+0x218] == 0x0"],

--- a/lib/one_gadget/fetchers/candidate_walk.rb
+++ b/lib/one_gadget/fetchers/candidate_walk.rb
@@ -55,7 +55,10 @@ module OneGadget
       # candidate at each leaf - {#find} then tries every start line within it.
       def back_walk(idx, forks, visited, path, &blk)
         addr = addr_at(idx)
-        return if path.size >= PATH_BUDGET
+        # Out of budget is a place to stop walking, not a reason to throw away
+        # what has been walked: the lines already on the path reach the call
+        # whether or not anything before them is ever looked at.
+        return blk.call(path.dup) if path.size >= PATH_BUDGET
 
         visited.add(addr)
         path.unshift(disasm_lines[idx])

--- a/lib/one_gadget/fetchers/mips.rb
+++ b/lib/one_gadget/fetchers/mips.rb
@@ -85,7 +85,10 @@ module OneGadget
       # @return [void]
       def executed_windows(lines)
         super do |window|
-          yield(window) unless follows_a_transfer_it_skipped?(window) || enters_at_an_unset_call?(window)
+          next if follows_a_transfer_it_skipped?(window) || enters_at_an_unset_call?(window)
+          next if calls_without_the_callee_in_t9?(window)
+
+          yield(window)
         end
       end
 
@@ -105,6 +108,70 @@ module OneGadget
       #   enters_at_an_unset_call?(['4b3dc: lw t9,-31652(gp)', '4b3e0: jalr t9']) #=> false
       def enters_at_an_unset_call?(window)
         mnemonic(window.first) == 'jalr'
+      end
+
+      # Whether the window calls a function that builds its own GOT base, without
+      # having put that function's address where the ABI says it reads it from.
+      # The call still arrives; what the callee then computes is wrong.
+      # @param [Array<String>] window
+      # @return [Boolean]
+      def calls_without_the_callee_in_t9?(window)
+        held = nil
+        window.each do |line|
+          if (load = line.match(GOT_LOAD))
+            held = got_address(load[1].to_i)
+          elsif (call = line.match(DIRECT_CALL))
+            target = call[1].to_i(16)
+            return true if held != target && derives_got_base?(target)
+          elsif line.match?(TARGET_WRITE)
+            held = nil
+          end
+        end
+        false
+      end
+
+      # A call that states its destination, as opposed to one through a register.
+      DIRECT_CALL = /:\s*(?:bal|jal)\s+([0-9a-f]+)/
+      private_constant :DIRECT_CALL
+
+      # Whether the function at +address+ derives its own GOT base, which o32 asks
+      # a callee to do from the address the caller leaves in +t9+ -- so a caller
+      # that has not put it there is calling a function that cannot find anything.
+      # @param [Integer] address
+      # @return [Boolean]
+      # @example The prologue this recognises, and a leaf that has none.
+      #   derives_got_base?(0x6653c) #=> true  (lui gp / addiu gp / addu gp,gp,t9)
+      #   derives_got_base?(0x66594) #=> false (sltiu v0,a1,256 / ...)
+      def derives_got_base?(address)
+        code = loaded_code or return false
+
+        index = (address - code[:base]) / INSTRUCTION_SIZE
+        return false if index.negative?
+
+        PROLOGUE_WORDS.times.any? { |i| code[:words][index + i] == GOT_BASE_FROM_TARGET }
+      end
+
+      # How far into a function to look for that prologue: it is the first thing a
+      # function does, ahead of anything that could need what it computes.
+      PROLOGUE_WORDS = 4
+      private_constant :PROLOGUE_WORDS
+
+      # +addu gp,gp,t9+, the instruction the prologue ends with.
+      GOT_BASE_FROM_TARGET = 0x0399e021
+      private_constant :GOT_BASE_FROM_TARGET
+
+      # The code the file loads, as words, so that an instruction can be read at an
+      # address without disassembling anything around it.
+      # @return [Hash{Symbol => Integer, Array<Integer>}, nil]
+      def loaded_code
+        return @loaded_code if defined?(@loaded_code)
+
+        @loaded_code = File.open(file) do |fd|
+          elf = ELFTools::ELFFile.new(fd)
+          segment = executable_segment(elf)
+          segment && { base: segment.header.p_vaddr.to_i,
+                       words: segment.data.unpack(elf.endian == :big ? 'N*' : 'V*') }
+        end
       end
 
       # @param [Array<String>] window

--- a/spec/fetchers/mips_spec.rb
+++ b/spec/fetchers/mips_spec.rb
@@ -36,10 +36,40 @@ describe OneGadget::Fetchers::Mips do
       expect(starts).to eq %w[1030 1000] # 1004 falls to 1008; it never reaches 1030
     end
 
+    # Where each window {OneGadget::Fetchers::Mips#executed_windows} still yields
+    # begins, so an example can say which of them survived.
+    def window_starts(lines)
+      [].tap { |acc| fetcher.executed_windows(lines) { |w| acc << w.first[/\A\w+/] } }
+    end
+
     it 'refuses to open on a call through a register it never set' do
       lines = ['1000: jalr t9 <posix_spawnattr_init>', '1004: move a0,s1', '1008: nop']
-      starts = [].tap { |acc| fetcher.executed_windows(lines) { |w| acc << w.first[/\A\w+/] } }
-      expect(starts).to eq %w[1004]
+      expect(window_starts(lines)).to eq %w[1004]
+    end
+
+    # o32 has a callee derive its own GOT base from the address the caller leaves
+    # in t9, so a window that reaches such a call is only good for as long as it
+    # has put the right address there. -30292(gp) holds posix_spawnattr_init and
+    # -30288(gp) holds posix_spawnattr_setsigmask.
+    it 'allows a call to a function that finds itself, once the window has aimed t9 at it' do
+      lines = ['1000: lw t9,-30292(gp)', '1004: bal 66578 <posix_spawnattr_init>', '1008: nop']
+      expect(window_starts(lines)).to eq %w[1000]
+    end
+
+    it 'refuses it where t9 was aimed at some other function' do
+      lines = ['1000: lw t9,-30288(gp)', '1004: bal 66578 <posix_spawnattr_init>', '1008: nop']
+      expect(window_starts(lines)).to be_empty
+    end
+
+    it 'refuses it where t9 was aimed and then overwritten' do
+      lines = ['1000: lw t9,-30292(gp)', '1004: move t9,s1',
+               '1008: bal 66578 <posix_spawnattr_init>', '100c: nop']
+      expect(window_starts(lines)).to be_empty
+    end
+
+    it 'asks nothing of t9 for a callee that never reads it' do
+      lines = ['1000: bal 665d0 <posix_spawnattr_setflags>', '1004: nop']
+      expect(window_starts(lines)).to eq %w[1000]
     end
 
     it 'runs the delay slot alone when entered at it, without the branch' do

--- a/spec/one_gadget_mips_spec.rb
+++ b/spec/one_gadget_mips_spec.rb
@@ -13,14 +13,18 @@ describe 'one_gadget_mips' do
     # both are read here.
     it 'musl 1.2.4, big-endian' do
       path = data_path('mips-musl-1.2.4.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x56fd4, 0x77b44, 0x77b48]
-      expect(OneGadget.gadgets(file: path, force_file: true, level: 1)).to eq [0x56fd4, 0x77b44, 0x77b48]
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x668e8, 0x668ec, 0x668f0, 0x668f4,
+                                                                     0x77b44, 0x77b48]
+      expect(OneGadget.gadgets(file: path, force_file: true, level: 1)).to eq [0x56fd4, 0x66898, 0x668e8, 0x668ec,
+                                                                               0x668f0, 0x668f4, 0x77b44, 0x77b48]
     end
 
     it 'musl 1.2.4, little-endian' do
       path = data_path('mipsel-musl-1.2.4.so')
-      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x56f98, 0x77b00, 0x77b04]
-      expect(OneGadget.gadgets(file: path, force_file: true, level: 1)).to eq [0x56f98, 0x77b00, 0x77b04]
+      expect(OneGadget.gadgets(file: path, force_file: true)).to eq [0x668ac, 0x668b0, 0x668b4, 0x668b8,
+                                                                     0x77b00, 0x77b04]
+      expect(OneGadget.gadgets(file: path, force_file: true, level: 1)).to eq [0x56f98, 0x6685c, 0x668ac, 0x668b0,
+                                                                               0x668b4, 0x668b8, 0x77b00, 0x77b04]
     end
 
     it 'libc-2.36' do


### PR DESCRIPTION
Running out of PATH_BUDGET returned without emitting, where running out of predecessors emits the path walked so far. A path long enough to hit the cap contributed nothing at all, so which gadgets a libc yields depended on how far back it had been disassembled -- which is what made a shorter window look like it was inventing them.

67 more gadgets across the fixtures, none lost. Verified strict: aarch64-2.43 148 PASS (was 143), MIPS 123 PASS (was 61).

Six of the recovered ones did not work, all opening at a bal. o32 has the callee build its own gp from t9, so a caller must leave the callee's address there; a window that skips the load establishing it calls a function that then finds nothing. MIPS now refuses those, reading the callee's prologue to tell whether it needs t9 at all -- posix_spawnattr_setflags does not, and that gadget verifies, so it is kept.