### PR TITLE
Keep the GOT setup search inside the window it started in

### DIFF
--- a/lib/one_gadget/fetchers/arm.rb
+++ b/lib/one_gadget/fetchers/arm.rb
@@ -242,13 +242,33 @@ module OneGadget
 
         lines = disasm_lines
         pattern = reg_patterns(reg)
-        add_at = pos.downto([0, pos - 400].max).find { |i| lines[i].match?(pattern[:add]) }
+        add_at = pos.downto(reachable_from(pos, SETUP_REACH)).find { |i| lines[i].match?(pattern[:add]) }
         return if add_at.nil?
 
-        ldr_at = add_at.downto([0, add_at - 4].max).find { |i| lines[i].match?(pattern[:ldr]) }
+        ldr_at = add_at.downto(reachable_from(add_at, LOAD_REACH)).find { |i| lines[i].match?(pattern[:ldr]) }
         return if ldr_at.nil?
 
         [lines[ldr_at], lines[add_at]]
+      end
+
+      # How far back to look for each half of the pair, in lines.
+      SETUP_REACH = 400
+      LOAD_REACH = 4
+      private_constant :SETUP_REACH, :LOAD_REACH
+
+      # The earliest line back from +pos+ that the line at +pos+ follows on from.
+      # {#disasm_lines} holds a window per terminal call, so a window's first line
+      # is where the code around it starts.
+      # @param [Integer] pos
+      # @param [Integer] reach
+      # @return [Integer]
+      # @example Where line 10 opens a window, line 12 can see back only that far.
+      #   window_starts           #=> { 10 => true }
+      #   reachable_from(12, 400) #=> 10
+      #   reachable_from(9, 400)  #=> 0
+      def reachable_from(pos, reach)
+        floor = [0, pos - reach].max
+        (floor..pos).reverse_each.find { |i| window_starts.key?(i) } || floor
       end
 
       def branch_lead_chars

--- a/spec/fetchers/arm_spec.rb
+++ b/spec/fetchers/arm_spec.rb
@@ -14,6 +14,29 @@ describe OneGadget::Fetchers::Arm do
     lines.map { |l| l[/\A\s*([0-9a-f]+):/, 1].to_i(16) }.sort
   end
 
+  # A GOT base register is established by an `ldr reg, [pc, ..]; add reg, pc` pair
+  # somewhere before the line that uses it, and the search for that pair walks back
+  # through the disassembly -- which holds a window per terminal call, not a whole
+  # file. It must not walk out of the window it started in.
+  describe 'how far back the GOT setup is looked for' do
+    let(:f) { fetcher('2.27') }
+
+    it 'stops where the window the line belongs to begins, not at an earlier one' do
+      allow(f).to receive(:window_starts).and_return({ 5 => true, 10 => true })
+      expect(f.send(:reachable_from, 12, 400)).to be 10
+    end
+
+    it 'goes the whole way back where nothing intervenes' do
+      allow(f).to receive(:window_starts).and_return({ 10 => true })
+      expect(f.send(:reachable_from, 9, 400)).to be 0
+    end
+
+    it 'reads a whole file as the one window it is' do
+      allow(f).to receive(:window_starts).and_return({})
+      expect(f.send(:reachable_from, 500, 400)).to be 100
+    end
+  end
+
   describe 'terminal_call_sites (BL byte scan)' do
     # The scan must miss no real bl-to-exec site (a false positive only adds a
     # harmless empty window, so we require superset, not equality). Gadget-level


### PR DESCRIPTION
disasm_lines holds a window per terminal call rather than a whole file, so the line before a window's first is the last of another, somewhere else entirely. The search for the ldr/add pair that establishes a GOT base walked back 400 lines by index regardless, and could take its answer from a function the path never reaches.

That is the second way a shorter window disagreed with a full disassembly: arm-2.27 reported an execve gadget at 0x8915c whose GOT base was seeded from code 0x11000 bytes away. At back=0x360 the arm fixtures now agree with a full disassembly exactly, where 73 of 254 lookups previously answered from past a window edge.

Nothing changes at the shipped window, and not by luck until now: 400 lines cannot span 0x1000 bytes, so the search could never reach an edge. The corpus is byte-identical at levels 0, 1 and 2.