### PR TITLE
Require elftools 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ releases are cut by giving that section a version and a date.
   once per binary rather than once per command ([#454]), the scan locating calls
   decodes far fewer words ([#456]), and a quarter as much is disassembled around
   each call ([#457]).
-- Requires elftools >= 2.1.0 ([#442]): searching a libc with no section headers
-  takes 0.68s, was 1.11s.
+- Requires elftools >= 2.2.0 ([#442], [#465]), which reads a symbol table without
+  building an object per symbol. A libc with no section headers searches in 0.24s,
+  was 0.44s; one with its sections intact is unchanged.
 
 ### Fixed
 
@@ -342,3 +343,4 @@ test corpus reports has been run under a debugger and seen to spawn a shell.
 [#456]: https://github.com/david942j/one_gadget/pull/456
 [#457]: https://github.com/david942j/one_gadget/pull/457
 [#460]: https://github.com/david942j/one_gadget/pull/460
+[#465]: https://github.com/david942j/one_gadget/pull/465

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     one_gadget (2.0.0)
-      elftools (>= 2.1.0, < 3.0.0)
+      elftools (>= 2.2.0, < 3.0.0)
       logger
 
 GEM
@@ -11,7 +11,7 @@ GEM
     ast (2.4.3)
     bindata (3.0.0)
     diff-lcs (1.6.2)
-    elftools (2.1.0)
+    elftools (2.2.0)
       bindata (>= 2, < 4)
     json (2.21.2)
     language_server-protocol (3.17.0.6)

--- a/one_gadget.gemspec
+++ b/one_gadget.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.3'
 
-  s.add_dependency 'elftools', '>= 2.1.0', '< 3.0.0'
+  s.add_dependency 'elftools', '>= 2.2.0', '< 3.0.0'
   s.add_dependency 'logger'
 
   s.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
2.2.0 reads a symbol table without building an object per symbol, which is the whole cost of reading a libc that ships without section headers. Such a libc now searches in 0.24s against 0.44s, and mipsel musl in 0.39s against 0.69s; one with its sections intact is unchanged, since that path never reads the dynamic symbols.

The spec suite goes 19.8s to 15.0s. Both measured interleaved, one version then the other, because this machine's timings drift enough over a few minutes to swamp the difference otherwise. The corpus is byte-identical at levels 0, 1 and 2.