### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Notable changes to one_gadget, newest first. The format follows
 A change worth a user's attention lands with its entry under *Unreleased*;
 releases are cut by giving that section a version and a date.
 
-## Unreleased
+## v2.1.0 - 2026-09-05
+
+Two more architectures, and a libc that ships without section headers -- as an
+embedded one usually does -- can now be searched at all.
 
 ### Added
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    one_gadget (2.0.0)
+    one_gadget (2.1.0)
       elftools (>= 2.2.0, < 3.0.0)
       logger
 

--- a/lib/one_gadget/version.rb
+++ b/lib/one_gadget/version.rb
@@ -2,5 +2,5 @@
 
 module OneGadget
   # Current gem version.
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
Two more architectures -- RISC-V and MIPS, both byte orders -- and a libc that ships without section headers, which is how an embedded one usually arrives. Every gadget the fixtures report for the new arches has been run under a debugger and seen to spawn a shell.

Also: 67 gadgets a backward walk had been discarding, searches roughly twice as fast on a stripped libc, and the gem's database no longer carries glibc 2.26.