### PR TITLE
Stop telling current users to update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Notable changes to one_gadget, newest first. The format follows
 A change worth a user's attention lands with its entry under *Unreleased*;
 releases are cut by giving that section a version and a date.
 
+## Unreleased
+
+### Fixed
+
+- Looking up a BuildID the gem does not ship no longer advises updating the gem
+  ([#467]). The gem carries 34 of 883 builds by design, so that advice reached
+  almost every remote lookup, and updating would not have added them. It now says
+  the build is being fetched.
+
 ## v2.1.0 - 2026-09-05
 
 Two more architectures, and a libc that ships without section headers -- as an
@@ -347,3 +356,4 @@ test corpus reports has been run under a debugger and seen to spawn a shell.
 [#457]: https://github.com/david942j/one_gadget/pull/457
 [#460]: https://github.com/david942j/one_gadget/pull/460
 [#465]: https://github.com/david942j/one_gadget/pull/465
+[#467]: https://github.com/david942j/one_gadget/pull/467

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -446,8 +446,7 @@ module OneGadget
         table = OneGadget::Helper.remote_builds.find { |c| c.include?(build_id) }
         return build_not_found if table.nil? # remote doesn't have this one either.
 
-        # builds found in remote! Ask update gem and download remote gadgets.
-        OneGadget::Logger.ask_update(msg: 'The desired one-gadget can be found in lastest version!')
+        OneGadget::Logger.info("#{build_id} is not shipped with the gem, fetching it from the repository\n")
         tmp_file = OneGadget::Helper.download_build(table)
         require tmp_file.path
         tmp_file.unlink

--- a/spec/gadget_spec.rb
+++ b/spec/gadget_spec.rb
@@ -311,8 +311,7 @@ constraints:
     allow(OneGadget::Helper).to receive(:url_request).with(/.rb$/).and_return('')
 
     expect { hook_logger { described_class.builds(id) } }.to output(<<-EOS).to_stdout
-[OneGadget] The desired one-gadget can be found in lastest version!
-            Update with: $ gem update one_gadget && gem cleanup one_gadget
+[OneGadget] remote_has_this is not shipped with the gem, fetching it from the repository
     EOS
     OneGadget::Gadget::ClassMethods::BUILDS.delete(id)
   end

--- a/spec/one_gadget_amd64_spec.rb
+++ b/spec/one_gadget_amd64_spec.rb
@@ -184,7 +184,7 @@ describe 'one_gadget_amd64' do
     it 'fetch from remote' do
       entry = OneGadget::Gadget::ClassMethods::BUILDS.delete(@build_id)
       # silence the logger
-      allow(OneGadget::Logger).to receive(:ask_update)
+      allow(OneGadget::Logger).to receive(:info)
       expect(OneGadget.gadgets(build_id: @build_id)).not_to be_empty
       OneGadget::Gadget::ClassMethods::BUILDS[@build_id] = entry unless entry.nil?
     end


### PR DESCRIPTION
A BuildID absent locally but present remotely was answered with "can be found in lastest version, update with gem update one_gadget". That held until 2.0.0, when the gem shipped every build; it now ships 34 of 883 by design, so the advice reached almost every remote lookup and updating would not have added them.

The lookup says what it is doing instead. It cannot go silent: nothing else in that path prints, and a lookup that looks local is about to use the network.