### PR TITLE
Fix five typos in documentation comments

### DIFF
--- a/lib/one_gadget/emulators/lambda.rb
+++ b/lib/one_gadget/emulators/lambda.rb
@@ -12,7 +12,7 @@ module OneGadget
     # 4. dereferenced {Lambda}
     class Lambda
       attr_accessor :obj # @return [String, Lambda] The object currently related to.
-      attr_accessor :immi # @return [Integer] The immidiate value currently added.
+      attr_accessor :immi # @return [Integer] The immediate value currently added.
       attr_accessor :deref_count # @return [Integer] The times of dereference.
       attr_accessor :op # @return [String, nil] The operator applied to {#obj}, for an operation (see {.operation}).
       attr_accessor :rhs # @return [Integer, Lambda, String, nil] The operator's right operand.
@@ -44,7 +44,7 @@ module OneGadget
       end
 
       # Implement subtract with +Numeric+.
-      # @param [Numeric] other Value to substract.
+      # @param [Numeric] other Value to subtract.
       # @return [Lambda] The result.
       def -(other)
         self + -other
@@ -58,7 +58,7 @@ module OneGadget
 
       # Decrease dereference count by 1.
       # @return [self]
-      # @raise [Error::InstrutionArgumentError] When this object cannot be referenced anymore.
+      # @raise [Error::InstructionArgumentError] When this object cannot be referenced anymore.
       def ref!
         raise Error::InstructionArgumentError, 'Cannot reference anymore!' if @deref_count <= 0
 

--- a/lib/one_gadget/fetchers/objdump.rb
+++ b/lib/one_gadget/fetchers/objdump.rb
@@ -39,7 +39,7 @@ module OneGadget
         @options = options
       end
 
-      # @param [Integer] start The start address to be dumpped from.
+      # @param [Integer] start The start address to be dumped from.
       # @param [Integer] stop The end address.
       # @param [Array<String>] extra Options for this range alone, on top of {#extra_options=}.
       # @return [String] The CLI command to be executed.

--- a/lib/one_gadget/gadget.rb
+++ b/lib/one_gadget/gadget.rb
@@ -456,7 +456,7 @@ module OneGadget
       # Returns the comments in builds/libc-*-<build_id>*.rb
       # @param [String] build_id
       #   Supports give only few starting bytes, but a warning will be shown
-      #   if multiple BulidIDs are matched.
+      #   if multiple BuildIDs are matched.
       # @return [String?]
       #   Lines of comments.
       # @example


### PR DESCRIPTION
immidiate, substract, dumpped and BulidIDs, plus a @raise naming Error::InstrutionArgumentError -- a class that does not exist, where the real one is InstructionArgumentError, so that tag resolved to nothing.

Found by checking every word of prose against codespell's dictionary and then against a full English wordlist; the remainder of what those flagged is technical vocabulary or this codebase's British spellings.