### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Notable changes to one_gadget, newest first. The format follows
 A change worth a user's attention lands with its entry under *Unreleased*;
 releases are cut by giving that section a version and a date.
 
-## Unreleased
+## v2.1.1 - 2026-09-05
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    one_gadget (2.1.0)
+    one_gadget (2.1.1)
       elftools (>= 2.2.0, < 3.0.0)
       logger
 

--- a/lib/one_gadget/version.rb
+++ b/lib/one_gadget/version.rb
@@ -2,5 +2,5 @@
 
 module OneGadget
   # Current gem version.
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
Every pre-generated entry is current again -- and a release is what delivers it, since a remote BuildID lookup reads from the latest tag, so until this one exists users still get the 2023-era gadgets.

Also stops telling people on the newest version to update it.